### PR TITLE
moneymong-387 feat: base usecase 제거

### DIFF
--- a/domain/src/main/java/com/moneymong/moneymong/domain/base/BaseUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/base/BaseUseCase.kt
@@ -1,5 +1,0 @@
-package com.moneymong.moneymong.domain.base
-
-abstract class BaseUseCase<P, R> {
-    abstract suspend operator fun invoke(data: P): R
-}

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/agency/FetchAgencyIdUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/agency/FetchAgencyIdUseCase.kt
@@ -1,12 +1,11 @@
 package com.moneymong.moneymong.domain.usecase.agency
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.AgencyRepository
 import javax.inject.Inject
 
 class FetchAgencyIdUseCase @Inject constructor(
     private val agencyRepository: AgencyRepository
-): BaseUseCase<Unit, Int>() {
-    override suspend fun invoke(data: Unit): Int =
+) {
+    suspend operator fun invoke(): Int =
         agencyRepository.fetchAgencyId()
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/agency/FetchMyAgencyListUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/agency/FetchMyAgencyListUseCase.kt
@@ -1,13 +1,12 @@
 package com.moneymong.moneymong.domain.usecase.agency
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.AgencyRepository
 import com.moneymong.moneymong.model.agency.MyAgencyResponse
 import javax.inject.Inject
 
 class FetchMyAgencyListUseCase @Inject constructor(
     private val agencyRepository: AgencyRepository
-): BaseUseCase<Unit, Result<List<MyAgencyResponse>>>() {
-    override suspend fun invoke(data: Unit): Result<List<MyAgencyResponse>> =
+) {
+    suspend operator fun invoke(): Result<List<MyAgencyResponse>> =
         agencyRepository.fetchMyAgencyList()
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/agency/RegisterAgencyUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/agency/RegisterAgencyUseCase.kt
@@ -1,7 +1,5 @@
 package com.moneymong.moneymong.domain.usecase.agency
 
-
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.AgencyRepository
 import com.moneymong.moneymong.model.agency.AgencyRegisterRequest
 import com.moneymong.moneymong.model.agency.RegisterAgencyResponse
@@ -9,8 +7,8 @@ import javax.inject.Inject
 
 class RegisterAgencyUseCase @Inject constructor(
     private val agencyRepository: AgencyRepository
-) : BaseUseCase<AgencyRegisterRequest, Result<RegisterAgencyResponse>>() {
-    override suspend operator fun invoke(data: AgencyRegisterRequest): Result<RegisterAgencyResponse> {
-        return agencyRepository.registerAgency(request = data)
+) {
+    suspend operator fun invoke(request: AgencyRegisterRequest): Result<RegisterAgencyResponse> {
+        return agencyRepository.registerAgency(request = request)
     }
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/agency/SaveAgencyIdUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/agency/SaveAgencyIdUseCase.kt
@@ -1,12 +1,11 @@
 package com.moneymong.moneymong.domain.usecase.agency
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.AgencyRepository
 import javax.inject.Inject
 
 class SaveAgencyIdUseCase @Inject constructor(
     private val agencyRepository: AgencyRepository
-): BaseUseCase<Int, Unit>() {
-    override suspend fun invoke(data: Int) =
-        agencyRepository.saveAgencyId(data)
+) {
+    suspend operator fun invoke(agencyId: Int) =
+        agencyRepository.saveAgencyId(agencyId)
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/ledger/FetchAgencyExistLedgerUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/ledger/FetchAgencyExistLedgerUseCase.kt
@@ -1,12 +1,11 @@
 package com.moneymong.moneymong.domain.usecase.ledger
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.ledger.LedgerRepository
 import javax.inject.Inject
 
 class FetchAgencyExistLedgerUseCase @Inject constructor(
     private val ledgerRepository: LedgerRepository
-) : BaseUseCase<Int, Result<Boolean>>() {
-    override suspend fun invoke(data: Int): Result<Boolean> =
-        ledgerRepository.fetchAgencyExistLedger(data)
+) {
+    suspend operator fun invoke(agencyId: Int): Result<Boolean> =
+        ledgerRepository.fetchAgencyExistLedger(agencyId)
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/ledgerdetail/DeleteLedgerDetailUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/ledgerdetail/DeleteLedgerDetailUseCase.kt
@@ -1,12 +1,11 @@
 package com.moneymong.moneymong.domain.usecase.ledgerdetail
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.ledgerdetail.LedgerDetailRepository
 import javax.inject.Inject
 
 class DeleteLedgerDetailUseCase @Inject constructor(
     private val ledgerDetailRepository: LedgerDetailRepository
-): BaseUseCase<Int, Result<Unit>>() {
-    override suspend fun invoke(data: Int): Result<Unit> =
-        ledgerDetailRepository.deleteLedgerDetail(data)
+) {
+    suspend operator fun invoke(detailId: Int): Result<Unit> =
+        ledgerDetailRepository.deleteLedgerDetail(detailId)
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/ledgerdetail/FetchLedgerTransactionDetailUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/ledgerdetail/FetchLedgerTransactionDetailUseCase.kt
@@ -1,13 +1,12 @@
 package com.moneymong.moneymong.domain.usecase.ledgerdetail
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.ledgerdetail.LedgerDetailRepository
 import com.moneymong.moneymong.model.ledgerdetail.LedgerTransactionDetailResponse
 import javax.inject.Inject
 
 class FetchLedgerTransactionDetailUseCase @Inject constructor(
     private val ledgerDetailRepository: LedgerDetailRepository
-): BaseUseCase<Int, Result<LedgerTransactionDetailResponse>>() {
-    override suspend fun invoke(data: Int): Result<LedgerTransactionDetailResponse> =
-        ledgerDetailRepository.fetchLedgerTransactionDetail(data)
+) {
+    suspend operator fun invoke(detailId: Int): Result<LedgerTransactionDetailResponse> =
+        ledgerDetailRepository.fetchLedgerTransactionDetail(detailId)
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/login/LoginUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/login/LoginUseCase.kt
@@ -1,16 +1,15 @@
 package com.moneymong.moneymong.domain.usecase.login
 
 import com.moneymong.moneymong.domain.util.LoginCallback
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.LoginRepository
 import javax.inject.Inject
 
 class LoginUseCase @Inject constructor(
     private val loginRepository: LoginRepository,
-) : BaseUseCase<LoginCallback, Unit>() {
+) {
 
-    override suspend fun invoke(data: LoginCallback) {
-        loginRepository.kakaoLogin(data)
+    suspend fun invoke(callback: LoginCallback) {
+        loginRepository.kakaoLogin(callback)
     }
 
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/member/MemberInvitationCodeUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/member/MemberInvitationCodeUseCase.kt
@@ -1,14 +1,13 @@
 package com.moneymong.moneymong.domain.usecase.member
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.member.MemberRepository
 import com.moneymong.moneymong.model.member.InvitationCodeResponse
 import javax.inject.Inject
 
 class MemberInvitationCodeUseCase @Inject constructor(
     private val memberRepository: MemberRepository
-) : BaseUseCase<Long, Result<InvitationCodeResponse>>() {
-    override suspend fun invoke(data: Long): Result<InvitationCodeResponse> {
-        return memberRepository.getInvitationCode(data)
+) {
+    suspend operator fun invoke(agencyId: Long): Result<InvitationCodeResponse> {
+        return memberRepository.getInvitationCode(agencyId)
     }
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/member/MemberListUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/member/MemberListUseCase.kt
@@ -1,15 +1,14 @@
 package com.moneymong.moneymong.domain.usecase.member
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.member.MemberRepository
 import com.moneymong.moneymong.model.member.MemberListResponse
 import javax.inject.Inject
 
 class MemberListUseCase @Inject constructor(
     private val memberRepository: MemberRepository
-) : BaseUseCase<Long, Result<MemberListResponse>>() {
+) {
 
-    override suspend fun invoke(data: Long): Result<MemberListResponse> {
-        return memberRepository.getMemberLists(data)
+    suspend operator fun invoke(agencyId: Long): Result<MemberListResponse> {
+        return memberRepository.getMemberLists(agencyId)
     }
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/member/MemberReInvitationCodeUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/member/MemberReInvitationCodeUseCase.kt
@@ -1,16 +1,15 @@
 package com.moneymong.moneymong.domain.usecase.member
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.member.MemberRepository
 import com.moneymong.moneymong.model.member.InvitationCodeResponse
 import javax.inject.Inject
 
 class MemberReInvitationCodeUseCase @Inject constructor(
     private val memberRepository: MemberRepository
-) : BaseUseCase<Long, Result<InvitationCodeResponse>>() {
+) {
 
-    override suspend fun invoke(data: Long): Result<InvitationCodeResponse> {
-        return memberRepository.reInvitationCode(data)
+    suspend operator fun invoke(agencyId: Long): Result<InvitationCodeResponse> {
+        return memberRepository.reInvitationCode(agencyId)
     }
 
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/ocr/DocumentOCRUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/ocr/DocumentOCRUseCase.kt
@@ -1,6 +1,5 @@
 package com.moneymong.moneymong.domain.usecase.ocr
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.ocr.OCRRepository
 import com.moneymong.moneymong.model.ocr.DocumentRequest
 import com.moneymong.moneymong.model.ocr.DocumentResponse
@@ -8,7 +7,7 @@ import javax.inject.Inject
 
 class DocumentOCRUseCase @Inject constructor(
     private val ocrRepository: OCRRepository
-): BaseUseCase<DocumentRequest, Result<DocumentResponse>>() {
-    override suspend fun invoke(data: DocumentRequest): Result<DocumentResponse> =
-        ocrRepository.documentOCR(data)
+) {
+    suspend operator fun invoke(request: DocumentRequest): Result<DocumentResponse> =
+        ocrRepository.documentOCR(request)
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/ocr/PostFileUploadUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/ocr/PostFileUploadUseCase.kt
@@ -1,6 +1,5 @@
 package com.moneymong.moneymong.domain.usecase.ocr
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.ocr.OCRRepository
 import com.moneymong.moneymong.model.ocr.FileUploadRequest
 import com.moneymong.moneymong.model.ocr.FileUploadResponse
@@ -8,7 +7,7 @@ import javax.inject.Inject
 
 class PostFileUploadUseCase @Inject constructor(
     private val ocrRepository: OCRRepository
-): BaseUseCase<FileUploadRequest, Result<FileUploadResponse>>() {
-    override suspend fun invoke(data: FileUploadRequest): Result<FileUploadResponse> =
-        ocrRepository.postFileUpload(data)
+) {
+    suspend operator fun invoke(request: FileUploadRequest): Result<FileUploadResponse> =
+        ocrRepository.postFileUpload(request)
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/signup/SchoolInfoUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/signup/SchoolInfoUseCase.kt
@@ -1,14 +1,13 @@
 package com.moneymong.moneymong.domain.usecase.signup
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.TokenRepository
 import javax.inject.Inject
 
 class SchoolInfoUseCase @Inject constructor(
     private val tokenRepository: TokenRepository
-) :BaseUseCase<Boolean, Unit>(){
+) {
 
-    override suspend fun invoke(data: Boolean){
-        tokenRepository.setSchoolInfoExist(data)
+    suspend operator fun invoke(infoExist: Boolean){
+        tokenRepository.setSchoolInfoExist(infoExist)
     }
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/signup/UnivUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/signup/UnivUseCase.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 
 class UnivUseCase @Inject constructor(
     private val univRepository: UnivRepository
-){
+) {
     suspend fun createUniv(body : UnivRequest) : Result<Unit>{
         return univRepository.createUniv(body)
     }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/FetchDeniedCameraPermissionUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/FetchDeniedCameraPermissionUseCase.kt
@@ -1,12 +1,11 @@
 package com.moneymong.moneymong.domain.usecase.user
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.user.UserRepository
 import javax.inject.Inject
 
 class FetchDeniedCameraPermissionUseCase @Inject constructor(
     private val userRepository: UserRepository
-): BaseUseCase<Unit, Boolean>() {
-    override suspend fun invoke(data: Unit): Boolean =
+) {
+    suspend operator fun invoke(): Boolean =
         userRepository.fetchDeniedCameraPermission()
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/FetchUserIdUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/FetchUserIdUseCase.kt
@@ -1,12 +1,11 @@
 package com.moneymong.moneymong.domain.usecase.user
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.user.UserRepository
 import javax.inject.Inject
 
 class FetchUserIdUseCase @Inject constructor(
     private val userRepository: UserRepository
-): BaseUseCase<Unit, Int>() {
-    override suspend fun invoke(data: Unit): Int =
+) {
+    suspend operator fun invoke(): Int =
         userRepository.fetchUserId()
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/FetchUserNicknameUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/FetchUserNicknameUseCase.kt
@@ -1,12 +1,11 @@
 package com.moneymong.moneymong.domain.usecase.user
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.user.UserRepository
 import javax.inject.Inject
 
 class FetchUserNicknameUseCase @Inject constructor(
     private val userRepository: UserRepository
-): BaseUseCase<Unit, String>() {
-    override suspend fun invoke(data: Unit): String =
+) {
+    suspend operator fun invoke(): String =
         userRepository.fetchUserNickName()
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/GetMyInfoUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/GetMyInfoUseCase.kt
@@ -1,15 +1,13 @@
 package com.moneymong.moneymong.domain.usecase.user
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.user.UserRepository
 import com.moneymong.moneymong.model.user.UserResponse
 import javax.inject.Inject
 
 class GetMyInfoUseCase @Inject constructor(
     private val userRepository: UserRepository
-) : BaseUseCase<Unit, Result<UserResponse>>() {
-
-    override suspend fun invoke(data: Unit): Result<UserResponse> {
+) {
+    suspend operator fun invoke(): Result<UserResponse> {
         return userRepository.getMyInfo()
     }
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/LogoutUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/LogoutUseCase.kt
@@ -1,14 +1,13 @@
 package com.moneymong.moneymong.domain.usecase.user
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.user.UserRepository
 import javax.inject.Inject
 
 class LogoutUseCase @Inject constructor(
     private val userRepository: UserRepository
-) : BaseUseCase<Unit, Result<Unit>>() {
+) {
 
-    override suspend fun invoke(data: Unit): Result<Unit> {
+    suspend operator fun invoke(): Result<Unit> {
         return userRepository.logout()
     }
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/SaveDeniedCameraPermissionUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/SaveDeniedCameraPermissionUseCase.kt
@@ -1,12 +1,11 @@
 package com.moneymong.moneymong.domain.usecase.user
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.user.UserRepository
 import javax.inject.Inject
 
 class SaveDeniedCameraPermissionUseCase @Inject constructor(
     private val userRepository: UserRepository
-): BaseUseCase<Boolean, Unit>() {
-    override suspend fun invoke(data: Boolean) =
-        userRepository.saveDeniedCameraPermission(data)
+) {
+    suspend operator fun invoke(isDenied: Boolean) =
+        userRepository.saveDeniedCameraPermission(isDenied)
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/SaveUserIdUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/SaveUserIdUseCase.kt
@@ -1,12 +1,11 @@
 package com.moneymong.moneymong.domain.usecase.user
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.user.UserRepository
 import javax.inject.Inject
 
 class SaveUserIdUseCase @Inject constructor(
     private val userRepository: UserRepository
-): BaseUseCase<Int, Unit>() {
-    override suspend fun invoke(data: Int) =
-        userRepository.saveUserId(data)
+) {
+    suspend operator fun invoke(userId: Int) =
+        userRepository.saveUserId(userId)
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/SaveUserNicknameUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/SaveUserNicknameUseCase.kt
@@ -1,12 +1,11 @@
 package com.moneymong.moneymong.domain.usecase.user
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.user.UserRepository
 import javax.inject.Inject
 
 class SaveUserNicknameUseCase @Inject constructor(
     private val userRepository: UserRepository
-): BaseUseCase<String, Unit>() {
-    override suspend fun invoke(data: String) =
-        userRepository.saveUserNickName(data)
+) {
+    suspend operator fun invoke(nickname: String) =
+        userRepository.saveUserNickName(nickname)
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/WithdrawalUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/WithdrawalUseCase.kt
@@ -1,14 +1,13 @@
 package com.moneymong.moneymong.domain.usecase.user
 
-import com.moneymong.moneymong.domain.base.BaseUseCase
 import com.moneymong.moneymong.domain.repository.user.UserRepository
 import javax.inject.Inject
 
 class WithdrawalUseCase @Inject constructor(
     private val userRepository: UserRepository
-) : BaseUseCase<Unit, Result<Unit>>() {
+) {
 
-    override suspend fun invoke(data: Unit): Result<Unit> {
+    suspend operator fun invoke(): Result<Unit> {
         return userRepository.withdrawal()
     }
 }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterViewModel.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterViewModel.kt
@@ -25,7 +25,7 @@ class AgencyRegisterViewModel @Inject constructor(
 
     fun registerAgency() = intent {
         registerAgencyUseCase(
-            data = AgencyRegisterRequest(
+            request = AgencyRegisterRequest(
                 name = state.agencyName.text,
                 type = state.agencyType.agencyRegisterTypeToString()
             )

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchViewModel.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchViewModel.kt
@@ -42,7 +42,7 @@ class AgencySearchViewModel @Inject constructor(
                 isError = false
             )
         }
-        fetchMyAgencyListUseCase(Unit)
+        fetchMyAgencyListUseCase()
             .also {
                 reduce { state.copy(isLoading = false) }
             }

--- a/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/LedgerViewModel.kt
+++ b/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/LedgerViewModel.kt
@@ -42,8 +42,8 @@ class LedgerViewModel @Inject constructor(
     }
 
     fun fetchDefaultInfo() = blockingIntent {
-        val agencyId = fetchAgencyIdUseCase(Unit)
-        val userId = fetchUserIdUseCase(Unit)
+        val agencyId = fetchAgencyIdUseCase()
+        val userId = fetchUserIdUseCase()
         reduce {
             state.copy(
                 agencyId = agencyId,
@@ -99,7 +99,7 @@ class LedgerViewModel @Inject constructor(
 
     fun fetchMyAgencyList() = blockingIntent {
         reduce { state.copy(isMyAgencyLoading = true) }
-        fetchMyAgencyListUseCase(Unit)
+        fetchMyAgencyListUseCase()
             .onSuccess {
                 reduce {
                     state.copy(

--- a/feature/ledgermanual/src/main/java/com/moneymong/moneymong/ledgermanual/LedgerManualViewModel.kt
+++ b/feature/ledgermanual/src/main/java/com/moneymong/moneymong/ledgermanual/LedgerManualViewModel.kt
@@ -36,8 +36,8 @@ class LedgerManualViewModel @Inject constructor(
 
     @OptIn(OrbitExperimental::class)
     fun fetchUserInfo() = blockingIntent {
-        val agencyId = fetchAgencyIdUseCase(Unit)
-        val userNickname = fetchUserNicknameUseCase(Unit)
+        val agencyId = fetchAgencyIdUseCase()
+        val userNickname = fetchUserNicknameUseCase()
         reduce {
             state.copy(
                 agencyId = agencyId,

--- a/feature/member/src/main/java/com/example/member/MemberScreen.kt
+++ b/feature/member/src/main/java/com/example/member/MemberScreen.kt
@@ -75,7 +75,7 @@ fun MemberScreen(
         viewModel.updateAgencyId(agencyId)
         viewModel.eventEmit(MemberSideEffect.GetInvitationCode(agencyId.toLong()))
         viewModel.eventEmit(MemberSideEffect.GetMemberLists(agencyId.toLong()))
-        viewModel.eventEmit(MemberSideEffect.GetMyInfo(Unit))
+        viewModel.eventEmit(MemberSideEffect.GetMyInfo)
     }
 
     if(state.isBlockedUser){
@@ -101,7 +101,7 @@ fun MemberScreen(
             }
 
             is MemberSideEffect.GetMyInfo -> {
-                viewModel.getMyInfo(it.data)
+                viewModel.getMyInfo()
             }
 
             is MemberSideEffect.UpdateMemberAuthor -> {
@@ -117,7 +117,7 @@ fun MemberScreen(
     LaunchedEffect(key1 = Unit) {
         viewModel.eventEmit(MemberSideEffect.GetInvitationCode(state.agencyId.toLong()))
         viewModel.eventEmit(MemberSideEffect.GetMemberLists(state.agencyId.toLong()))
-        viewModel.eventEmit(MemberSideEffect.GetMyInfo(Unit))
+        viewModel.eventEmit(MemberSideEffect.GetMyInfo)
     }
 
 
@@ -174,7 +174,7 @@ fun MemberScreen(
             onConfirm = {
                 viewModel.eventEmit(MemberSideEffect.GetInvitationCode(state.agencyId.toLong()))
                 viewModel.eventEmit(MemberSideEffect.GetMemberLists(state.agencyId.toLong()))
-                viewModel.eventEmit(MemberSideEffect.GetMyInfo(Unit))
+                viewModel.eventEmit(MemberSideEffect.GetMyInfo)
                 viewModel.visiblePopUpErrorChanged(false)
             }
         )
@@ -351,7 +351,7 @@ fun MemberScreen(
                 viewModel.visibleErrorChanged(false)
                 viewModel.eventEmit(MemberSideEffect.GetInvitationCode(state.agencyId.toLong()))
                 viewModel.eventEmit(MemberSideEffect.GetMemberLists(state.agencyId.toLong()))
-                viewModel.eventEmit(MemberSideEffect.GetMyInfo(Unit))
+                viewModel.eventEmit(MemberSideEffect.GetMyInfo)
             }
         )
         Column(

--- a/feature/member/src/main/java/com/example/member/MemberSideEffect.kt
+++ b/feature/member/src/main/java/com/example/member/MemberSideEffect.kt
@@ -6,7 +6,7 @@ sealed class MemberSideEffect : SideEffect {
     data class GetInvitationCode(val agencyId: Long) : MemberSideEffect()
     data class GetReInvitationCode(val agencyId: Long) : MemberSideEffect()
     data class GetMemberLists(val agencyId: Long) : MemberSideEffect()
-    data class GetMyInfo(val data: Unit) : MemberSideEffect()
     data class UpdateMemberAuthor(val agencyId: Long, val role : String, val userId : Long) : MemberSideEffect()
     data class BlockMemberAuthor(val agencyId: Long, val userId: Long) : MemberSideEffect()
+    data object GetMyInfo : MemberSideEffect()
 }

--- a/feature/member/src/main/java/com/example/member/MemberViewModel.kt
+++ b/feature/member/src/main/java/com/example/member/MemberViewModel.kt
@@ -36,7 +36,7 @@ class MemberViewModel @Inject constructor(
 
     @OptIn(OrbitExperimental::class)
     fun fetchAgencyId() = blockingIntent {
-        val agencyId = fetchAgencyIdUseCase(Unit)
+        val agencyId = fetchAgencyIdUseCase()
         reduce { state.copy(agencyId = agencyId) }
     }
 
@@ -220,8 +220,8 @@ class MemberViewModel @Inject constructor(
             }
     }
 
-    fun getMyInfo(data: Unit) = intent {
-        getMyInfoUseCase.invoke(Unit)
+    fun getMyInfo() = intent {
+        getMyInfoUseCase.invoke()
             .onSuccess {
                 reduce {
                     state.copy(

--- a/feature/mymong/src/main/java/com/moneymong/moneymong/feature/mymong/main/MyMongViewModel.kt
+++ b/feature/mymong/src/main/java/com/moneymong/moneymong/feature/mymong/main/MyMongViewModel.kt
@@ -42,7 +42,7 @@ class MyMongViewModel @Inject constructor(
                 isInfoError = false,
             )
         }
-        getMyInfoUseCase(data = Unit)
+        getMyInfoUseCase()
             .also {
                 reduce {
                     state.copy(isInfoLoading = false)
@@ -67,7 +67,7 @@ class MyMongViewModel @Inject constructor(
     }
 
     fun logout() = intent {
-        logoutUseCase(data = Unit)
+        logoutUseCase()
             .onSuccess {
                 clearLocalData()
                 postSideEffect(sideEffect = MyMongSideEffect.NavigateToLogin)

--- a/feature/mymong/src/main/java/com/moneymong/moneymong/feature/mymong/withdrawal/WithdrawalViewModel.kt
+++ b/feature/mymong/src/main/java/com/moneymong/moneymong/feature/mymong/withdrawal/WithdrawalViewModel.kt
@@ -21,7 +21,7 @@ class WithdrawalViewModel @Inject constructor(
 ) : BaseViewModel<WithdrawalState, WithdrawalSideEffect>(WithdrawalState()) {
 
     fun withdrawal() = intent {
-        withdrawalUseCase(data = Unit)
+        withdrawalUseCase()
             .onSuccess {
                 clearLocalData()
                 postSideEffect(WithdrawalSideEffect.NavigateToLogin)

--- a/feature/ocr-detail/src/main/java/com/moneymong/moneymong/ocr_detail/OCRDetailViewModel.kt
+++ b/feature/ocr-detail/src/main/java/com/moneymong/moneymong/ocr_detail/OCRDetailViewModel.kt
@@ -76,8 +76,8 @@ class OCRDetailViewModel @Inject constructor(
 
     @OptIn(OrbitExperimental::class)
     fun fetchUserInfo() = blockingIntent {
-        val agencyId = fetchAgencyIdUseCase(Unit)
-        val userNickname = fetchUserNicknameUseCase(Unit)
+        val agencyId = fetchAgencyIdUseCase()
+        val userNickname = fetchUserNicknameUseCase()
         reduce {
             state.copy(
                 agencyId = agencyId,

--- a/feature/ocr-result/src/main/java/com/moneymong/moneymong/ocr_result/OCRResultViewModel.kt
+++ b/feature/ocr-result/src/main/java/com/moneymong/moneymong/ocr_result/OCRResultViewModel.kt
@@ -34,7 +34,7 @@ class OCRResultViewModel @Inject constructor(
 
     @OptIn(OrbitExperimental::class)
     fun fetchAgencyId() = blockingIntent {
-        val agencyId = fetchAgencyIdUseCase(Unit)
+        val agencyId = fetchAgencyIdUseCase()
         reduce { state.copy(agencyId = agencyId) }
     }
 

--- a/feature/ocr/src/main/java/com/moneymong/moneymong/ocr/OCRViewModel.kt
+++ b/feature/ocr/src/main/java/com/moneymong/moneymong/ocr/OCRViewModel.kt
@@ -69,7 +69,7 @@ class OCRViewModel @Inject constructor(
 
     @OptIn(OrbitExperimental::class)
     fun fetchDeniedCameraPermission() = blockingIntent {
-        val isDeniedCamera = fetchDeniedCameraPermissionUseCase(Unit)
+        val isDeniedCamera = fetchDeniedCameraPermissionUseCase()
         reduce { state.copy(isDeniedCamera = isDeniedCamera) }
     }
 


### PR DESCRIPTION
## 요약
domain layer에 있던 BaseUseCase코드를 제거합니다.
## 작업내용
- domain layer base usecase 제거
- usecase param 네이밍 수정
## 기타
기존에 BaseUseCase를 상속받아 UseCase를 구현하는 방식을 사용할 필요가 없어졌습니다. 
각 feature의 UseCase 내부에서 invoke operator 함수를 직접 구현하여 사용하면 됩니다.