### PR TITLE
Feature/moneymong 472 소속 에러화면 수정

### DIFF
--- a/core/design-system/src/main/java/com/moneymong/moneymong/design_system/error/ErrorDialog.kt
+++ b/core/design-system/src/main/java/com/moneymong/moneymong/design_system/error/ErrorDialog.kt
@@ -32,6 +32,8 @@ import com.moneymong.moneymong.design_system.R
 import com.moneymong.moneymong.design_system.component.button.MDSButton
 import com.moneymong.moneymong.design_system.component.button.MDSButtonSize
 import com.moneymong.moneymong.design_system.component.button.MDSButtonType
+import com.moneymong.moneymong.design_system.theme.Body4
+import com.moneymong.moneymong.design_system.theme.Gray05
 import com.moneymong.moneymong.design_system.theme.Gray10
 import com.moneymong.moneymong.design_system.theme.Heading1
 import com.moneymong.moneymong.design_system.theme.MMHorizontalSpacing
@@ -41,6 +43,7 @@ import com.moneymong.moneymong.design_system.theme.White
 fun ErrorDialog(
     modifier: Modifier = Modifier,
     message: String,
+    subMessage: String? = null,
     onConfirm: () -> Unit
 ) {
     val horizontalPadding = 22.dp
@@ -77,6 +80,15 @@ fun ErrorDialog(
                 style = Heading1,
                 color = Gray10
             )
+            if (subMessage != null) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = subMessage,
+                    textAlign = TextAlign.Center,
+                    style = Body4,
+                    color = Gray05
+                )
+            }
             Spacer(modifier = Modifier.height(16.dp))
             MDSButton(
                 modifier = Modifier.width(buttonWidth),
@@ -104,6 +116,28 @@ fun ErrorDialogPreview() {
         ) {
             ErrorDialog(
                 message = "ddddddddddddddddddddddddddddddddddddddddddddddddddd",
+                onConfirm = { visibleDialog = false }
+            )
+        }
+    }
+}
+
+
+@Preview(
+    showBackground = true,
+    device = "spec:shape=Normal,width=240,height=640, unit=dp, dpi= 480"
+)
+@Composable
+fun ErrorDialogWithSubMessagePreview() {
+    var visibleDialog by remember { mutableStateOf(true) }
+
+    if (visibleDialog) {
+        Box(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            ErrorDialog(
+                message = "ddddddddddddddddddddddddddddddddddddddddddddddddddd",
+                subMessage = "장부 페이지에서 가입한 소속을 확인해보세요",
                 onConfirm = { visibleDialog = false }
             )
         }

--- a/core/design-system/src/main/java/com/moneymong/moneymong/design_system/error/ErrorDialog.kt
+++ b/core/design-system/src/main/java/com/moneymong/moneymong/design_system/error/ErrorDialog.kt
@@ -43,7 +43,7 @@ import com.moneymong.moneymong.design_system.theme.White
 fun ErrorDialog(
     modifier: Modifier = Modifier,
     message: String,
-    subMessage: String? = null,
+    subMessage: String = "",
     onConfirm: () -> Unit
 ) {
     val horizontalPadding = 22.dp
@@ -80,7 +80,7 @@ fun ErrorDialog(
                 style = Heading1,
                 color = Gray10
             )
-            if (subMessage != null) {
+            if (subMessage.isNotBlank()) {
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
                     text = subMessage,

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
@@ -69,9 +69,13 @@ fun AgencySearchScreen(
     }
 
     if (state.visibleWarningDialog) {
-        ErrorDialog(message = "이미 가입된 소속입니다") {
-            viewModel.changeVisibleWarningDialog(false)
-        }
+        ErrorDialog(
+            message = "이미 가입한 소속입니다",
+            subMessage = "장부 페이지에서 가입한 소속을 확인해보세요",
+            onConfirm = {
+                viewModel.changeVisibleWarningDialog(false)
+            }
+        )
     }
 
     Box(


### PR DESCRIPTION
## 요약
이미 가입한 소속을 가입하려고 할 때, 표시되는 `error dialog` 를 수정했습니다!

## 작업내용
- 에러 메시지 멘트를 수정했어요!
- 서브 메시지를 추가했어요!
- DesignSystem `ErrorDialog` 컴포넌트에 subMessage 파라미터를 추가했습니다!

### 스크린 샷

|기존|수정|
|:----:|:----:|
|<img width="300" src="https://github.com/MONEYMONG/Android-Moneymong/assets/80373033/b9572273-d8c7-4b90-bdfd-9249e182fe88">|<img width="300" src="https://github.com/MONEYMONG/Android-Moneymong/assets/80373033/18a3f9d7-8a15-4551-9e3d-02a65f1aa3ac">|


## 기타
subMessage 가 다른 화면에서 `public` 하게 사용될 수 있는 UI 라고 생각해서 `MDS` 의 `ErrorDialog` 컴포넌트에 적용했습니다!