### PR TITLE
Feature/moneymong 471 초대코드 지우기

### DIFF
--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/agency/AgencyJoinUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/agency/AgencyJoinUseCase.kt
@@ -8,8 +8,10 @@ import javax.inject.Inject
 class AgencyJoinUseCase @Inject constructor(
     private val agencyRepository: AgencyRepository
 ) {
-    suspend fun invoke(agencyId: Long, data: AgencyJoinRequest): Result<AgencyJoinResponse> {
+    suspend operator fun invoke(
+        agencyId: Long,
+        data: AgencyJoinRequest
+    ): Result<AgencyJoinResponse> {
         return agencyRepository.agencyCodeNumbers(agencyId, data)
     }
-
 }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/AgencyCompleteScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/AgencyCompleteScreen.kt
@@ -2,14 +2,10 @@ package com.moneymong.moneymong.feature.agency.join
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import com.moneymong.moneymong.design_system.R
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -23,6 +19,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.moneymong.moneymong.common.ui.noRippleClickable
+import com.moneymong.moneymong.design_system.R
 import com.moneymong.moneymong.design_system.theme.Black
 import com.moneymong.moneymong.design_system.theme.Heading1
 import com.moneymong.moneymong.design_system.theme.MMHorizontalSpacing

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/AgencyCompleteState.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/AgencyCompleteState.kt
@@ -2,6 +2,6 @@ package com.moneymong.moneymong.feature.agency.join
 
 import com.moneymong.moneymong.common.base.State
 
-data class AgencyCompleteState (
-    val isBtnClicked : Boolean = false
+data class AgencyCompleteState(
+    val isBtnClicked: Boolean = false
 ) : State

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/AgencyJoinSideEffect.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/AgencyJoinSideEffect.kt
@@ -2,5 +2,5 @@ package com.moneymong.moneymong.feature.agency.join
 
 import com.moneymong.moneymong.common.base.SideEffect
 
-sealed class AgencyJoinSideEffect : SideEffect{
+sealed class AgencyJoinSideEffect : SideEffect {
 }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/AgencyJoinState.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/AgencyJoinState.kt
@@ -2,10 +2,10 @@ package com.moneymong.moneymong.feature.agency.join
 
 import com.moneymong.moneymong.common.base.State
 
-data class AgencyJoinState (
-    val isError : Boolean = false,
-    val numbers : List<String> = listOf("", "", "", "", "" , ""),
-    val codeAccess : Boolean = false,
-    val visiblePopUpError : Boolean = false,
-    val errorPopUpMessage : String = ""
+data class AgencyJoinState(
+    val isError: Boolean = false,
+    val inputCode: String = "",
+    val codeAccess: Boolean = false,
+    val visiblePopUpError: Boolean = false,
+    val errorPopUpMessage: String = ""
 ) : State

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/AgencyJoinViewModel.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/AgencyJoinViewModel.kt
@@ -1,5 +1,6 @@
 package com.moneymong.moneymong.feature.agency.join
 
+import androidx.core.text.isDigitsOnly
 import androidx.lifecycle.viewModelScope
 import com.moneymong.moneymong.common.base.BaseViewModel
 import com.moneymong.moneymong.domain.usecase.agency.AgencyJoinUseCase
@@ -58,7 +59,7 @@ class AgencyJoinViewModel @Inject constructor(
 
     fun changeInputNumber(input: String) = intent intent@{
         with(input) {
-            if (state.isError.not() && (length <= CODE_MAX_SIZE)) {
+            if (isDigitsOnly() && state.isError.not() && (length <= CODE_MAX_SIZE)) {
                 this@intent.reduce {
                     state.copy(inputCode = input)
                 }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/AgencyJoinViewModel.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/AgencyJoinViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.moneymong.moneymong.common.base.BaseViewModel
 import com.moneymong.moneymong.domain.usecase.agency.AgencyJoinUseCase
 import com.moneymong.moneymong.domain.usecase.agency.SaveAgencyIdUseCase
+import com.moneymong.moneymong.feature.agency.join.component.CODE_MAX_SIZE
 import com.moneymong.moneymong.model.agency.AgencyJoinRequest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -13,14 +14,13 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AgencyJoinViewModel @Inject constructor(
-    private val useCase: AgencyJoinUseCase,
+    private val agencyJoinUseCase: AgencyJoinUseCase,
     private val saveAgencyIdUseCase: SaveAgencyIdUseCase
 ) : BaseViewModel<AgencyJoinState, AgencyJoinSideEffect>(AgencyJoinState()) {
 
-    fun agencyCodeNumbers(agencyId: Long) = intent {
-        val codeNumbers = state.numbers.joinToString(separator = "")
+    fun checkInviteCode(agencyId: Long) = intent {
         viewModelScope.launch {
-            useCase.invoke(agencyId, AgencyJoinRequest(codeNumbers))
+            agencyJoinUseCase(agencyId = agencyId, data = AgencyJoinRequest(state.inputCode))
                 .onSuccess {
                     if (it.certified) {
                         saveAgencyIdUseCase(agencyId.toInt())
@@ -45,45 +45,36 @@ class AgencyJoinViewModel @Inject constructor(
                             errorPopUpMessage = it.message.toString()
                         )
                     }
-
                 }
         }
-
     }
 
 
     fun onIsErrorChanged(newIsError: Boolean) = intent {
         reduce {
-            state.copy(
-                isError = newIsError
-            )
+            state.copy(isError = newIsError)
         }
     }
 
-    fun onIsNumbersChanged(index: Int, value: String) = intent {
-        val newNumbers = state.numbers.toMutableList().apply {
-            this[index] = value
-        }
-        reduce {
-            state.copy(
-                numbers = newNumbers
-            )
+    fun changeInputNumber(input: String) = intent intent@{
+        with(input) {
+            if (state.isError.not() && (length <= CODE_MAX_SIZE)) {
+                this@intent.reduce {
+                    state.copy(inputCode = input)
+                }
+            }
         }
     }
 
     fun resetNumbers() = intent {
         reduce {
-            state.copy(
-                numbers = List(6) { "" }
-            )
+            state.copy(inputCode = "")
         }
     }
 
     fun visiblePopUpErrorChanged(visibleError: Boolean) = intent {
         reduce {
-            state.copy(
-                visiblePopUpError = visibleError,
-            )
+            state.copy(visiblePopUpError = visibleError)
         }
     }
 }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/component/AgencyCompleteButtonView.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/component/AgencyCompleteButtonView.kt
@@ -6,19 +6,16 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.moneymong.moneymong.design_system.component.button.MDSButton
 import com.moneymong.moneymong.design_system.component.button.MDSButtonSize
 import com.moneymong.moneymong.design_system.component.button.MDSButtonType
-import com.moneymong.moneymong.feature.agency.join.AgencyCompleteState
-import com.moneymong.moneymong.feature.agency.join.AgencyCompleteViewModel
 
 @Composable
-fun AgencyCompleteButtonView (
+fun AgencyCompleteButtonView(
     modifier: Modifier = Modifier,
-    isBtnClickChanged : (Boolean) -> Unit
-){
+    isBtnClickChanged: (Boolean) -> Unit
+) {
 
     Column(
         modifier = modifier
@@ -34,6 +31,5 @@ fun AgencyCompleteButtonView (
             enabled = true
         )
         Spacer(modifier = Modifier.height(28.dp))
-
     }
 }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/component/AgencyInviteCodeView .kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/component/AgencyInviteCodeView .kt
@@ -1,77 +1,48 @@
 package com.moneymong.moneymong.feature.agency.join.component
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.moneymong.moneymong.design_system.R
 import com.moneymong.moneymong.design_system.theme.Blue04
 import com.moneymong.moneymong.design_system.theme.Body2
-import com.moneymong.moneymong.design_system.theme.Gray01
-import com.moneymong.moneymong.design_system.theme.Gray03
-import com.moneymong.moneymong.design_system.theme.Heading1
 import com.moneymong.moneymong.design_system.theme.Red02
 import com.moneymong.moneymong.design_system.theme.White
-import com.moneymong.moneymong.feature.agency.join.AgencyJoinState
-import com.moneymong.moneymong.feature.agency.join.AgencyJoinViewModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
+import com.moneymong.moneymong.feature.agency.join.component.invitecode.InviteCodeField
 
 
-@OptIn(ExperimentalComposeUiApi::class)
+internal const val CODE_MAX_SIZE = 6
+
 @Composable
 fun AgencyInviteCodeView(
-    agencyId : Long,
-    focusRequesters: List<FocusRequester>,
-    isError : Boolean,
-    numbers : List<String>,
-    agencyCodeNumbers : (Long) -> Unit,
-    onIsErrorChanged: (Boolean) -> Unit,
-    onIsNumbersChanged: (Int, String) -> Unit,
+    modifier: Modifier = Modifier,
+    isError: Boolean,
+    inputCode: String,
+    onValueChanged: (String) -> Unit,
+    checkInviteCode: () -> Unit,
 ) {
 
+    val value by rememberUpdatedState(newValue = inputCode)
+    val allNumbersEntered by remember { derivedStateOf { value.length == CODE_MAX_SIZE } }
 
-    val allNumbersEntered = numbers.none { it.isEmpty() }
-    val keyboardController = LocalSoftwareKeyboardController.current
-    val focusManager = LocalFocusManager.current
-
-
-    // 모든 숫자가 입력되었고, 조건을 만족하지 않는 경우 isError를 true로 설정
     LaunchedEffect(key1 = allNumbersEntered) {
-        onIsErrorChanged(isError)
-    }
-
-    //포커스를 첫번째 textField로 설정
-    LaunchedEffect(key1 = Unit) {
-        focusRequesters[0].requestFocus()
+        if (allNumbersEntered) {
+            checkInviteCode()
+        }
     }
 
     Column(
-        modifier = Modifier
-            .background(White)
+        modifier = modifier.background(White)
     ) {
         Text(
             modifier = Modifier
@@ -81,53 +52,12 @@ fun AgencyInviteCodeView(
             color = if (!isError) Blue04 else Red02,
             style = Body2
         )
-
-
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(10.dp)
-        ) {
-            numbers.forEachIndexed { index, value ->
-                val visibleCode = value.isEmpty() || isError
-
-                if (visibleCode) {
-                    OutlinedTextField(
-                        value = value,
-                        onValueChange = { newValue ->
-                            if (newValue.length == 1 ) {
-                                onIsNumbersChanged(index, newValue)
-                                if (index == numbers.lastIndex) {
-                                    keyboardController?.hide()
-                                    focusManager.clearFocus()
-                                    agencyCodeNumbers(agencyId)
-                                }
-                            }
-                        },
-                        modifier = Modifier
-                            .weight(1f)
-                            .aspectRatio(180 / 288f)
-                            .background(if (isError) Gray01 else White)
-                            .focusRequester(focusRequesters[index]),
-                        keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number),
-                        textStyle = Heading1.copy(textAlign = TextAlign.Center),
-                        singleLine = true,
-                        shape = RoundedCornerShape(8.dp),
-                        colors = OutlinedTextFieldDefaults.colors(
-                            focusedBorderColor = if (isError) Red02 else Blue04,
-                            unfocusedBorderColor = if (isError) Red02 else Gray03
-                        ),
-                    )
-                } else {
-                    Image(
-                        modifier = Modifier.weight(1f),
-                        painter = painterResource(id = R.drawable.img_code),
-                        contentDescription = null
-                    )
-                }
-            }
-        }
+        Spacer(modifier = Modifier.height(8.dp))
+        InviteCodeField(
+            modifier = Modifier.fillMaxWidth(),
+            value = value,
+            onValueChange = onValueChanged,
+            isError = isError
+        )
     }
 }
-

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/component/AgencyInviteCodeView .kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/component/AgencyInviteCodeView .kt
@@ -13,6 +13,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.unit.dp
 import com.moneymong.moneymong.design_system.theme.Blue04
 import com.moneymong.moneymong.design_system.theme.Body2
@@ -26,6 +28,7 @@ internal const val CODE_MAX_SIZE = 6
 @Composable
 fun AgencyInviteCodeView(
     modifier: Modifier = Modifier,
+    focusRequester: FocusRequester,
     isError: Boolean,
     inputCode: String,
     onValueChanged: (String) -> Unit,
@@ -54,7 +57,9 @@ fun AgencyInviteCodeView(
         )
         Spacer(modifier = Modifier.height(8.dp))
         InviteCodeField(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = modifier
+                .focusRequester(focusRequester)
+                .fillMaxWidth(),
             value = value,
             onValueChange = onValueChanged,
             isError = isError

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/component/AgencyInviteCodeView .kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/component/AgencyInviteCodeView .kt
@@ -57,7 +57,7 @@ fun AgencyInviteCodeView(
         )
         Spacer(modifier = Modifier.height(8.dp))
         InviteCodeField(
-            modifier = modifier
+            modifier = Modifier
                 .focusRequester(focusRequester)
                 .fillMaxWidth(),
             value = value,

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/component/invitecode/InviteCodeField.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/component/invitecode/InviteCodeField.kt
@@ -1,0 +1,147 @@
+package com.moneymong.moneymong.feature.agency.join.component.invitecode
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.moneymong.moneymong.design_system.R
+import com.moneymong.moneymong.design_system.theme.Black
+import com.moneymong.moneymong.design_system.theme.Heading1
+import com.moneymong.moneymong.feature.agency.join.component.CODE_MAX_SIZE
+
+@Composable
+internal fun InviteCodeField(
+    modifier: Modifier = Modifier,
+    value: String,
+    onValueChange: (String) -> Unit,
+    isError: Boolean = false
+) {
+    BasicTextField(
+        modifier = modifier,
+        value = value,
+        onValueChange = onValueChange,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        decorationBox = {
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                val containerModifier = Modifier
+                    .aspectRatio(45 / 72f)
+                    .weight(1f)
+
+                if (isError) {
+                    value.forEach { char ->
+                        InviteNumberFieldContainer(
+                            modifier = containerModifier,
+                            text = char,
+                            state = InviteCodeFieldState.ERROR
+                        )
+                    }
+                } else {
+                    value.forEach { char ->
+                        InviteNumberFieldContainer(
+                            modifier = containerModifier,
+                            text = char,
+                            state = InviteCodeFieldState.FILLED
+                        )
+                    }
+                    if (value.length < CODE_MAX_SIZE) {
+                        InviteNumberFieldContainer(
+                            modifier = containerModifier,
+                            text = ' ',
+                            state = InviteCodeFieldState.FOCUSED
+                        )
+                    }
+                    repeat(CODE_MAX_SIZE - value.length - 1) {
+                        InviteNumberFieldContainer(
+                            modifier = containerModifier,
+                            text = ' ',
+                            state = InviteCodeFieldState.EMPTY
+                        )
+                    }
+                }
+            }
+        }
+    )
+}
+
+
+@Composable
+private fun InviteNumberFieldContainer(
+    modifier: Modifier = Modifier,
+    text: Char,
+    state: InviteCodeFieldState
+) {
+
+    val baseContainer: @Composable (Modifier, Color, Color) -> Unit =
+        { containerModifier, backgroundColor, borderColor ->
+            Box(
+                modifier = containerModifier
+                    .clip(RoundedCornerShape(size = 8.dp))
+                    .background(color = backgroundColor)
+                    .run {
+                        border(
+                            width = 1.dp,
+                            color = borderColor,
+                            shape = RoundedCornerShape(8.dp)
+                        )
+
+                    },
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = text.toString(),
+                    color = Black,
+                    style = Heading1,
+                )
+            }
+        }
+
+
+    when (state) {
+        is InviteCodeFieldState.FILLED -> {
+            Image(
+                modifier = modifier,
+                painter = painterResource(id = R.drawable.img_code),
+                contentDescription = null
+            )
+        }
+
+        is InviteCodeFieldState.EMPTY -> {
+            baseContainer(
+                modifier,
+                state.backgroundColor,
+                state.borderColor
+            )
+        }
+
+        is InviteCodeFieldState.FOCUSED -> {
+            baseContainer(
+                modifier,
+                state.backgroundColor,
+                state.borderColor
+            )
+        }
+
+        is InviteCodeFieldState.ERROR -> {
+            baseContainer(
+                modifier,
+                state.backgroundColor,
+                state.borderColor
+            )
+        }
+    }
+}

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/component/invitecode/InviteCodeField.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/component/invitecode/InviteCodeField.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -16,7 +17,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.moneymong.moneymong.design_system.R
@@ -31,11 +34,17 @@ internal fun InviteCodeField(
     onValueChange: (String) -> Unit,
     isError: Boolean = false
 ) {
+    val focusManager = LocalFocusManager.current
+
     BasicTextField(
         modifier = modifier,
         value = value,
         onValueChange = onValueChange,
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        keyboardOptions = KeyboardOptions(
+            keyboardType = KeyboardType.Number,
+            imeAction = ImeAction.Done
+        ),
+        keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
         decorationBox = {
             Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                 val containerModifier = Modifier

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/component/invitecode/InviteCodeFieldState.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/component/invitecode/InviteCodeFieldState.kt
@@ -1,0 +1,33 @@
+package com.moneymong.moneymong.feature.agency.join.component.invitecode
+
+import androidx.compose.ui.graphics.Color
+import com.moneymong.moneymong.design_system.theme.Blue04
+import com.moneymong.moneymong.design_system.theme.Gray01
+import com.moneymong.moneymong.design_system.theme.Gray03
+import com.moneymong.moneymong.design_system.theme.Red02
+import com.moneymong.moneymong.design_system.theme.White
+
+internal sealed class InviteCodeFieldState {
+
+    interface Defaults {
+        val backgroundColor: Color
+        val borderColor: Color
+    }
+
+    data object FILLED : InviteCodeFieldState()
+
+    data object EMPTY : InviteCodeFieldState(), Defaults {
+        override val backgroundColor: Color = White
+        override val borderColor: Color = Gray03
+    }
+
+    data object FOCUSED : InviteCodeFieldState(), Defaults {
+        override val backgroundColor: Color = White
+        override val borderColor: Color = Blue04
+    }
+
+    data object ERROR : InviteCodeFieldState(), Defaults {
+        override val backgroundColor: Color = Gray01
+        override val borderColor: Color = Red02
+    }
+}


### PR DESCRIPTION
## 요약
입력된 초대 코드 지우기가 되지 않던 버그를 수정했습니다.

## 작업내용
- 여러 개의 `TextField` 로 이뤄진 기존 초대 코드 UI 를 하나의 `TextField` 로 수정했습니다.
- 초대 코드 상태(`InviteCodeFieldState`) 를 정의 하고 그에 따라 UI 색상을 지정합니다.
- 기존의 스낵바가 키보드 영역에 가려지는 현상을 해결했습니다.

### 동작 화면

|기존|수정|
|:----:|:----:|
|<img width="300" src="https://github.com/MONEYMONG/Android-Moneymong/assets/80373033/c2bcde48-03d5-4b15-9bee-35461eb5a31c">|<img width="300" src="https://github.com/MONEYMONG/Android-Moneymong/assets/80373033/41ba3575-98bc-43a2-ba14-501275b27f67">|

## 기타
`AgencyJoinScreen.kt` 129Line 에 아래와 같은 코드가 존재합니다.
```kotlin
val snackbarFadeOutMillis = 75L //  androidx.compose.material3.SnackbarHostState.kt
delay(snackbarFadeOutMillis)
focusRequester.requestFocus()
```
이는 잘못된 초대코드 스낵바의 다시 입력 버튼 클릭 시, 스낵바가 사라지면서 키보드가 올라가는 현상이 보기에 깔끔하지 않아
이를 막고자 의도적으로 스낵바의 사라진 뒤, 키보드가 올라가도록 했습니다.
**75**란 숫자는 아래와 같이 `androidx.compose.material3.SnackbarHostState.kt` 에 내부적으로 지정되어 있습니다.

<img width="400" src="https://github.com/MONEYMONG/Android-Moneymong/assets/80373033/f7edf92e-f388-48f0-9d74-b88184c3985c">