### PR TITLE
Feature/moneymong 495 마이몽 대학 정보X 대응

### DIFF
--- a/feature/mymong/src/main/java/com/moneymong/moneymong/feature/mymong/main/MyMongScreen.kt
+++ b/feature/mymong/src/main/java/com/moneymong/moneymong/feature/mymong/main/MyMongScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -77,6 +79,7 @@ fun MyMongScreen(
         modifier = modifier
             .fillMaxSize()
             .background(color = Gray01)
+            .verticalScroll(state = rememberScrollState())
             .padding(horizontal = MMHorizontalSpacing),
     ) {
         MyMongTopBar(modifier = Modifier.align(Alignment.CenterHorizontally))

--- a/feature/mymong/src/main/java/com/moneymong/moneymong/feature/mymong/main/view/MyMongInfoView.kt
+++ b/feature/mymong/src/main/java/com/moneymong/moneymong/feature/mymong/main/view/MyMongInfoView.kt
@@ -146,7 +146,9 @@ fun UniversityInfo(
                 style = Body3
             )
             Spacer(modifier = Modifier.height(6.dp))
-            Row {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 Image(
                     modifier = Modifier.size(24.dp),
                     painter = painterResource(id = R.drawable.img_university),

--- a/feature/mymong/src/main/java/com/moneymong/moneymong/feature/mymong/main/view/MyMongInfoView.kt
+++ b/feature/mymong/src/main/java/com/moneymong/moneymong/feature/mymong/main/view/MyMongInfoView.kt
@@ -21,8 +21,8 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.moneymong.moneymong.design_system.R
-import com.moneymong.moneymong.design_system.error.ErrorItem
 import com.moneymong.moneymong.design_system.component.indicator.LoadingItem
+import com.moneymong.moneymong.design_system.error.ErrorItem
 import com.moneymong.moneymong.design_system.theme.Blue04
 import com.moneymong.moneymong.design_system.theme.Body2
 import com.moneymong.moneymong.design_system.theme.Body3
@@ -126,6 +126,12 @@ fun UniversityInfo(
     university: String,
     grade: Int
 ) {
+    val universityInfoText = when {
+        university.isEmpty() -> "정보 없음"
+        grade == 5 -> "$university ${grade}학년 이상"
+        else -> "$university ${grade}학년"
+    }
+
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -148,7 +154,7 @@ fun UniversityInfo(
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                    text = "$university $grade" + if (grade == 5) "학년 이상" else "학년",
+                    text = universityInfoText,
                     color = Gray08,
                     style = Body4
                 )

--- a/feature/mymong/src/main/java/com/moneymong/moneymong/feature/mymong/main/view/MyMongInfoView.kt
+++ b/feature/mymong/src/main/java/com/moneymong/moneymong/feature/mymong/main/view/MyMongInfoView.kt
@@ -97,7 +97,7 @@ private fun Profile(
         Spacer(modifier = Modifier.width(16.dp))
         Column {
             Text(
-                text = name,
+                text = name + "님",
                 color = Gray10,
                 style = Heading1
             )


### PR DESCRIPTION
## 요약
- 마이몽 화면에서 대학 정보 없음에 따른 UI 대응

## 작업내용
### 스크린 샷
<img width = "300" src = "https://github.com/user-attachments/assets/fb8ce43d-bd35-4ece-9051-d5eddeb95ecb"/>

## 기타
- 마이몽 화면에 스크롤 기능을 넣은 이유는 사용자의 디바이스 글씨 크기가 커지면 화면이 잘릴 수 있기 때문입니다!~