### PR TITLE
Feature/moneymong 485 온보딩 흰색줄 노출 이슈

### DIFF
--- a/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/view/onboarding/LedgerOnboarding.kt
+++ b/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/view/onboarding/LedgerOnboarding.kt
@@ -9,15 +9,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.window.Popup
-import androidx.compose.ui.window.PopupPositionProvider
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.moneymong.moneymong.design_system.theme.Gray10
 import com.moneymong.moneymong.design_system.theme.White
+import com.moneymong.moneymong.ledger.view.onboarding.popup.LedgerOnboardingPopup
 import java.time.LocalDate
 
 
@@ -68,9 +64,7 @@ internal fun LedgerOnboarding(
         }
     }
 
-    Popup(
-        popupPositionProvider = LedgerPopupPositionProvider()
-    ) {
+    LedgerOnboardingPopup {
         when (currentPage) {
             LedgerOnboardingPage.DATE -> {
                 LedgerOnboardingDatePage(
@@ -100,21 +94,5 @@ internal fun LedgerOnboarding(
                 )
             }
         }
-    }
-}
-
-
-private class LedgerPopupPositionProvider : PopupPositionProvider {
-    override fun calculatePosition(
-        anchorBounds: IntRect,
-        windowSize: IntSize,
-        layoutDirection: LayoutDirection,
-        popupContentSize: IntSize
-    ): IntOffset {
-
-        return IntOffset(
-            x = 0,
-            y = 0
-        )
     }
 }

--- a/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/view/onboarding/popup/LedgerOnboardingPopup.kt
+++ b/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/view/onboarding/popup/LedgerOnboardingPopup.kt
@@ -1,0 +1,39 @@
+package com.moneymong.moneymong.ledger.view.onboarding.popup
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCompositionContext
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalView
+
+@Composable
+internal fun LedgerOnboardingPopup(
+    content: @Composable () -> Unit
+) {
+    val view = LocalView.current
+    val parentComposition = rememberCompositionContext()
+    val currentContent by rememberUpdatedState(content)
+    val popupLayout = remember {
+        LedgerOnboardingPopupLayout(
+            composeView = view
+        ).apply {
+            setContent(parentComposition) {
+                currentContent()
+            }
+        }
+    }
+
+    DisposableEffect(key1 = popupLayout) {
+        popupLayout.show()
+
+        onDispose {
+            popupLayout.disposeComposition()
+            popupLayout.dismiss()
+        }
+    }
+}
+
+
+

--- a/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/view/onboarding/popup/LedgerOnboardingPopupLayout.kt
+++ b/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/view/onboarding/popup/LedgerOnboardingPopupLayout.kt
@@ -1,0 +1,95 @@
+package com.moneymong.moneymong.ledger.view.onboarding.popup
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.PixelFormat
+import android.view.Gravity
+import android.view.View
+import android.view.WindowManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionContext
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.AbstractComposeView
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeViewModelStoreOwner
+import androidx.savedstate.findViewTreeSavedStateRegistryOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+
+
+@SuppressLint("ViewConstructor")
+internal class LedgerOnboardingPopupLayout(
+    private val composeView: View,
+) : AbstractComposeView(composeView.context) {
+
+    private val windowManager =
+        composeView.context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+    private val params = createLayoutParams()
+    private var content: @Composable () -> Unit by mutableStateOf({})
+
+
+    init {
+        id = android.R.id.content
+        setViewTreeLifecycleOwner(composeView.findViewTreeLifecycleOwner())
+        setViewTreeViewModelStoreOwner(composeView.findViewTreeViewModelStoreOwner())
+        setViewTreeSavedStateRegistryOwner(composeView.findViewTreeSavedStateRegistryOwner())
+    }
+
+    @Composable
+    override fun Content() {
+        content()
+    }
+
+    fun setContent(parent: CompositionContext, content: @Composable () -> Unit) {
+        setParentCompositionContext(parent)
+        this.content = content
+    }
+
+    fun show() {
+        windowManager.addView(this, params)
+    }
+
+    fun dismiss() {
+        setViewTreeLifecycleOwner(null)
+        windowManager.removeViewImmediate(this)
+    }
+
+
+    private fun createLayoutParams(): WindowManager.LayoutParams {
+        return WindowManager.LayoutParams().apply {
+            // Start to position the popup in the top left corner, a new position will be calculated
+            gravity = Gravity.START or Gravity.TOP
+
+            // Flags specific to android.widget.PopupWindow
+            flags = flags and (
+                    WindowManager.LayoutParams.FLAG_IGNORE_CHEEK_PRESSES or
+                            WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or
+                            WindowManager.LayoutParams.FLAG_SPLIT_TOUCH
+                    ).inv()
+
+            // Make the popup window not focusable
+            flags = flags or WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+
+            // Enables us to intercept outside clicks even when popup is not focusable
+            flags = flags or WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH
+
+            type = WindowManager.LayoutParams.TYPE_APPLICATION_SUB_PANEL
+
+            // Get the Window token from the parent view
+            token = composeView.applicationWindowToken
+
+            // Set the popup window to occupy the entire screen
+            width = WindowManager.LayoutParams.MATCH_PARENT
+            height = WindowManager.LayoutParams.MATCH_PARENT
+
+            format = PixelFormat.TRANSLUCENT
+
+            // accessibilityTitle is not exposed as a public API therefore we set popup window
+            // title which is used as a fallback by a11y services
+            title = "LedgerOnboardingPopup"
+        }
+    }
+}


### PR DESCRIPTION
## 요약
- 특정 기기에서 장부 온보딩 화면 하단에 흰색줄이 노출되던 이슈를 해결했습니다!

## 작업내용
- Compose Popup 을 기반으로 Custom Popup 을 만들어 대응했습니다.

###  스크린 샷
> Pixel 3a

|기존 온보딩 하단|수정 후 온보딩 하단|
|:----:|:----:|
|<img width="300" src="https://github.com/user-attachments/assets/85ee6c7c-c996-4dd8-b354-c35c41a8bd7a">|<img width="300" src="https://github.com/user-attachments/assets/0cb908cd-ba0a-4ac0-989d-e280fde40a46">|

## 기타
- Compose 에서 제공하는 Popup 컴포넌트를 기반으로, 필요한 부분만 수정하고 불필요한 부분은 제거했습니다.
   ```kotlin
    // 수정된 부분
    width = WindowManager.LayoutParams.MATCH_PARENT
    height = WindowManager.LayoutParams.MATCH_PARENT
  ```
  - 자세한 내용은 제 블로그에! [블로그](https://jik3410.tistory.com/17)
- https://github.com/MONEYMONG/Android-Moneymong/pull/7#discussion_r1644480296 해당 이슈도 함께 해결되었습니다!
