### PR TITLE
Feature/moneymong 493 회원가입 대학정보없음

### DIFF
--- a/core/model/src/main/java/com/moneymong/moneymong/model/sign/TokenRequest.kt
+++ b/core/model/src/main/java/com/moneymong/moneymong/model/sign/TokenRequest.kt
@@ -2,5 +2,7 @@ package com.moneymong.moneymong.model.sign
 
 data class TokenRequest (
     val provider : String,
-    val accessToken : String
+    val accessToken : String,
+    val name: String,
+    val code: String
 )

--- a/core/model/src/main/java/com/moneymong/moneymong/model/sign/TokenResponse.kt
+++ b/core/model/src/main/java/com/moneymong/moneymong/model/sign/TokenResponse.kt
@@ -4,5 +4,6 @@ data class TokenResponse(
     val accessToken : String,
     val refreshToken : String,
     val loginSuccess : Boolean,
-    val schoolInfoExist : Boolean
+    val schoolInfoExist : Boolean,
+    val schoolInfoProvided: Boolean
 )

--- a/core/model/src/main/java/com/moneymong/moneymong/model/sign/UnivRequest.kt
+++ b/core/model/src/main/java/com/moneymong/moneymong/model/sign/UnivRequest.kt
@@ -1,6 +1,6 @@
 package com.moneymong.moneymong.model.sign
 
 data class UnivRequest(
-    val universityName: String,
-    val grade: Int
+    val universityName: String?,
+    val grade: Int?
 )

--- a/core/model/src/main/java/com/moneymong/moneymong/model/sign/UserDataStoreInfoResponse.kt
+++ b/core/model/src/main/java/com/moneymong/moneymong/model/sign/UserDataStoreInfoResponse.kt
@@ -2,5 +2,5 @@ package com.moneymong.moneymong.model.sign
 
 data class UserDataStoreInfoResponse(
     val accessToken : String,
-    val schoolInfoExist : Boolean,
+    val schoolInfoProvided : Boolean,
 )

--- a/data/src/main/java/com/moneymong/moneymong/data/datasource/login/LoginLocalDataSource.kt
+++ b/data/src/main/java/com/moneymong/moneymong/data/datasource/login/LoginLocalDataSource.kt
@@ -11,5 +11,5 @@ interface LoginLocalDataSource {
     suspend fun updateTokens(aToken: String, rToken: String)
     suspend fun updateAccessToken(aToken: String)
     suspend fun getSchoolInfo(): Result<Boolean>
-    suspend fun setSchoolInfoExist(infoExist: Boolean)
+    suspend fun setSchoolInfoProvided(infoExist: Boolean)
 }

--- a/data/src/main/java/com/moneymong/moneymong/data/datasource/login/LoginLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/moneymong/moneymong/data/datasource/login/LoginLocalDataSourceImpl.kt
@@ -19,7 +19,7 @@ class LoginLocalDataSourceImpl @Inject constructor(
     private val accessToken = stringPreferencesKey("ACCESS_TOKEN")
     private val refreshToken = stringPreferencesKey("REFRESH_TOKEN")
     private val loginSuccess = booleanPreferencesKey("LOGIN_SUCCESS")
-    private val schoolInfoExist = booleanPreferencesKey("SCHOOL_INFO_EXIST")
+    private val schoolInfoProvided = booleanPreferencesKey("SCHOOL_INFO_PROVIDED")
 
     override suspend fun getRefreshToken(): Result<String> {
         val preferences = context.dataStore.data.first()
@@ -35,7 +35,7 @@ class LoginLocalDataSourceImpl @Inject constructor(
 
     override suspend fun getDataStoreInfo(): Result<UserDataStoreInfoResponse> {
         val preferences = context.dataStore.data.first()
-        return Result.success(UserDataStoreInfoResponse(preferences[accessToken] ?: "",preferences[schoolInfoExist] ?: false))
+        return Result.success(UserDataStoreInfoResponse(preferences[accessToken] ?: "",preferences[schoolInfoProvided] ?: false))
     }
 
     override suspend fun updateTokens(aToken: String, rToken: String) {
@@ -53,8 +53,8 @@ class LoginLocalDataSourceImpl @Inject constructor(
 
     override suspend fun getSchoolInfo(): Result<Boolean> {
         val preferences = context.dataStore.data.first()
-        return preferences[schoolInfoExist]?.let { Result.success(it) }
-            ?: Result.failure(Exception("schoolInfoExist is null"))
+        return preferences[schoolInfoProvided]?.let { Result.success(it) }
+            ?: Result.failure(Exception("schoolInfoProvided is null"))
     }
 
     override suspend fun deleteToken() {
@@ -62,7 +62,7 @@ class LoginLocalDataSourceImpl @Inject constructor(
             preferences.remove(accessToken)
             preferences.remove(refreshToken)
             preferences.remove(loginSuccess)
-            preferences.remove(schoolInfoExist)
+            preferences.remove(schoolInfoProvided)
         }
     }
 
@@ -76,14 +76,13 @@ class LoginLocalDataSourceImpl @Inject constructor(
             preferences[accessToken] = aToken
             preferences[refreshToken] = rToken
             preferences[loginSuccess] = success
-            preferences[schoolInfoExist] = infoExist
-            Log.d("schoolInfoExist", preferences[schoolInfoExist]!!.toString())
+            preferences[schoolInfoProvided] = infoExist
         }
     }
 
-    override suspend fun setSchoolInfoExist(infoExist: Boolean) {
+    override suspend fun setSchoolInfoProvided(infoExist: Boolean) {
         context.dataStore.edit { preferences ->
-            preferences[schoolInfoExist] = infoExist
+            preferences[schoolInfoProvided] = infoExist
         }
 
     }

--- a/data/src/main/java/com/moneymong/moneymong/data/datasource/login/TokenRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/moneymong/moneymong/data/datasource/login/TokenRemoteDataSourceImpl.kt
@@ -18,7 +18,7 @@ class TokenRemoteDataSourceImpl @Inject constructor(
         type: LoginType,
         accessToken: String
     ): Result<TokenResponse> {
-        return accessTokenApi.postAccessToken(TokenRequest(type.name, accessToken))
+        return accessTokenApi.postAccessToken(TokenRequest(type.name, accessToken, "", ""))
     }
 
     override suspend fun getUpdateToken(refreshToken: String): Result<RefreshTokenResponse> {

--- a/data/src/main/java/com/moneymong/moneymong/data/repository/token/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/moneymong/moneymong/data/repository/token/TokenRepositoryImpl.kt
@@ -31,7 +31,7 @@ class TokenRepositoryImpl @Inject constructor(
                 it.accessToken,
                 it.refreshToken,
                 it.loginSuccess,
-                it.schoolInfoExist
+                it.schoolInfoProvided
             )
         }
     }
@@ -68,8 +68,8 @@ class TokenRepositoryImpl @Inject constructor(
         return loginLocalDataSource.getSchoolInfo()
     }
 
-    override suspend fun setSchoolInfoExist(infoExist: Boolean) {
-        return loginLocalDataSource.setSchoolInfoExist(infoExist)
+    override suspend fun setSchoolInfoProvided(infoExist: Boolean) {
+        return loginLocalDataSource.setSchoolInfoProvided(infoExist)
     }
 
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/repository/TokenRepository.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/repository/TokenRepository.kt
@@ -20,5 +20,5 @@ interface TokenRepository {
     suspend fun updateAccessToken(aToken: String)
     suspend fun deleteRefreshToken(body: RefreshTokenRequest)
     suspend fun getSchoolInfo(): Result<Boolean>
-    suspend fun setSchoolInfoExist(infoExist: Boolean)
+    suspend fun setSchoolInfoProvided(infoExist: Boolean)
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/signup/SchoolInfoUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/signup/SchoolInfoUseCase.kt
@@ -8,6 +8,6 @@ class SchoolInfoUseCase @Inject constructor(
 ) {
 
     suspend operator fun invoke(infoExist: Boolean){
-        tokenRepository.setSchoolInfoExist(infoExist)
+        tokenRepository.setSchoolInfoProvided(infoExist)
     }
 }

--- a/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/LoginScreen.kt
+++ b/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/LoginScreen.kt
@@ -36,12 +36,12 @@ fun LoginScreen(
     val state = viewModel.collectAsState().value
     val context = LocalContext.current
 
-    LaunchedEffect(key1 = state.isSchoolInfoExist) {
-        if (state.isSchoolInfoExist == true) {
+    LaunchedEffect(key1 = state.isSchoolInfoProvided) {
+        if (state.isSchoolInfoProvided == true) {
             navigateToLedger()
-        } else if (state.isSchoolInfoExist == false) {
+        } else if (state.isSchoolInfoProvided == false) {
             navigateToSignup()
-            viewModel.isSchoolInfoExistChanged(null)
+            viewModel.isSchoolInfoProvidedChanged(null)
         }
     }
 

--- a/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/SignUpScreen.kt
+++ b/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/SignUpScreen.kt
@@ -73,7 +73,7 @@ fun SignUpScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .background(White)
-                .padding(MMHorizontalSpacing),
+                .padding(horizontal = MMHorizontalSpacing),
             topBar = {
                 Row(
                     modifier = Modifier
@@ -209,7 +209,7 @@ fun SignUpContent(
             }
         }
 
-        Column(
+        Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.BottomCenter)

--- a/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/SignUpScreen.kt
+++ b/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/SignUpScreen.kt
@@ -231,7 +231,6 @@ fun SignUpContent(
                             )
                         )
                     },
-                    storeSchoolInfoExist = { viewModel.storeSchoolInfoExist(it) }
                 )
             }
         }

--- a/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/SignUpScreen.kt
+++ b/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/SignUpScreen.kt
@@ -209,7 +209,7 @@ fun SignUpContent(
             }
         }
 
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.BottomCenter)

--- a/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/state/LoginState.kt
+++ b/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/state/LoginState.kt
@@ -4,7 +4,7 @@ import com.moneymong.moneymong.common.base.State
 
 data class LoginState(
     val isClickable: Boolean = false,
-    val isSchoolInfoExist: Boolean? = null,
+    val isSchoolInfoProvided: Boolean? = null,
     val isLoginRequired: Boolean? = null,
     val visibleError : Boolean = false,
     val errorMessage : String = ""

--- a/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/view/SignUpButtonView.kt
+++ b/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/view/SignUpButtonView.kt
@@ -5,19 +5,17 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.moneymong.moneymong.common.ui.noRippleClickable
 import com.moneymong.moneymong.design_system.component.button.MDSButton
 import com.moneymong.moneymong.design_system.component.button.MDSButtonSize
 import com.moneymong.moneymong.design_system.component.button.MDSButtonType
 import com.moneymong.moneymong.design_system.error.ErrorDialog
 import com.moneymong.moneymong.design_system.theme.Blue04
 import com.moneymong.moneymong.design_system.theme.Body3
-import com.moneymong.moneymong.feature.sign.sideeffect.SignUpSideEffect
 
 @Composable
 fun SignUpButtonView(
@@ -27,7 +25,6 @@ fun SignUpButtonView(
     popUpErrorMessage: String,
     visiblePopUpErrorChanged: (Boolean) -> Unit,
     onCreateUniversity: () -> Unit,
-    storeSchoolInfoExist: (Boolean) -> Unit
 ) {
     if (visiblePopUpError) {
         ErrorDialog(
@@ -44,25 +41,25 @@ fun SignUpButtonView(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {
                     onCreateUniversity()
-                    storeSchoolInfoExist(true)
                 },
                 text = "가입하기",
                 type = MDSButtonType.PRIMARY,
                 size = MDSButtonSize.LARGE,
                 enabled = isEnabled
             )
-            Spacer(modifier = Modifier.height(8.dp))
-            TextButton(
-                modifier = Modifier.align(Alignment.CenterHorizontally),
-                onClick = { onCreateUniversity() }
-            ){
-                Text(
-                    textAlign = TextAlign.Center,
-                    text = "입력할 대학 정보가 없어요",
-                    color = Blue04,
-                    style = Body3
-                )
-            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .noRippleClickable {
+                        onCreateUniversity()
+                    },
+                textAlign = TextAlign.Center,
+                text = "입력할 대학 정보가 없어요",
+                color = Blue04,
+                style = Body3
+            )
+
         }
     }
 }

--- a/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/view/SignUpButtonView.kt
+++ b/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/view/SignUpButtonView.kt
@@ -60,6 +60,9 @@ fun SignUpButtonView(
                 style = Body3
             )
 
+            Spacer(modifier = Modifier.height(28.dp))
+
+
         }
     }
 }

--- a/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/view/SignUpButtonView.kt
+++ b/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/view/SignUpButtonView.kt
@@ -4,33 +4,39 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.material.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.moneymong.moneymong.design_system.component.button.MDSButton
 import com.moneymong.moneymong.design_system.component.button.MDSButtonSize
 import com.moneymong.moneymong.design_system.component.button.MDSButtonType
 import com.moneymong.moneymong.design_system.error.ErrorDialog
+import com.moneymong.moneymong.design_system.theme.Blue04
+import com.moneymong.moneymong.design_system.theme.Body3
+import com.moneymong.moneymong.feature.sign.sideeffect.SignUpSideEffect
 
 @Composable
 fun SignUpButtonView(
-    modifier: Modifier = Modifier ,
-    isEnabled : Boolean,
-    visiblePopUpError : Boolean,
-    popUpErrorMessage : String,
-    visiblePopUpErrorChanged : (Boolean) -> Unit,
-    onCreateUniversity : () -> Unit,
-    storeSchoolInfoExist : (Boolean) -> Unit
+    modifier: Modifier = Modifier,
+    isEnabled: Boolean,
+    visiblePopUpError: Boolean,
+    popUpErrorMessage: String,
+    visiblePopUpErrorChanged: (Boolean) -> Unit,
+    onCreateUniversity: () -> Unit,
+    storeSchoolInfoExist: (Boolean) -> Unit
 ) {
-    if(visiblePopUpError){
+    if (visiblePopUpError) {
         ErrorDialog(
             message = popUpErrorMessage,
             onConfirm = {
                 visiblePopUpErrorChanged(false)
             }
         )
-    }
-    else{
+    } else {
         Column(
             modifier = modifier
         ) {
@@ -46,7 +52,17 @@ fun SignUpButtonView(
                 enabled = isEnabled
             )
             Spacer(modifier = Modifier.height(8.dp))
-
+            TextButton(
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                onClick = { onCreateUniversity() }
+            ){
+                Text(
+                    textAlign = TextAlign.Center,
+                    text = "입력할 대학 정보가 없어요",
+                    color = Blue04,
+                    style = Body3
+                )
+            }
         }
     }
 }

--- a/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/viewmodel/LoginViewModel.kt
+++ b/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/viewmodel/LoginViewModel.kt
@@ -46,13 +46,13 @@ class LoginViewModel @Inject constructor(
             if (result) {
                 reduce {
                     state.copy(
-                        isSchoolInfoExist = true
+                        isSchoolInfoProvided = true
                     )
                 }
             } else {
                 reduce {
                     state.copy(
-                        isSchoolInfoExist = false
+                        isSchoolInfoProvided = false
                     )
                 }
             }
@@ -93,10 +93,10 @@ class LoginViewModel @Inject constructor(
         }
     }
 
-    fun isSchoolInfoExistChanged(isSchoolInfoExist: Boolean?) = intent {
+    fun isSchoolInfoProvidedChanged(isSchoolInfoProvided: Boolean?) = intent {
         reduce {
             state.copy(
-                isSchoolInfoExist = isSchoolInfoExist
+                isSchoolInfoProvided = isSchoolInfoProvided
             )
         }
     }

--- a/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/viewmodel/SignUpViewModel.kt
+++ b/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/viewmodel/SignUpViewModel.kt
@@ -27,6 +27,7 @@ class SignUpViewModel @Inject constructor(
         val body = UnivRequest(universityName, grade)
         univUseCase.createUniv(body)
             .onSuccess {
+                storeSchoolInfoExist(true)
                 reduce {
                     state.copy(
                         isUnivCreated = true

--- a/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/viewmodel/SignUpViewModel.kt
+++ b/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/viewmodel/SignUpViewModel.kt
@@ -27,7 +27,7 @@ class SignUpViewModel @Inject constructor(
         val body = UnivRequest(universityName, grade)
         univUseCase.createUniv(body)
             .onSuccess {
-                storeSchoolInfoExist(true)
+                storeSchoolInfoProvided(true)
                 reduce {
                     state.copy(
                         isUnivCreated = true
@@ -62,7 +62,7 @@ class SignUpViewModel @Inject constructor(
             }
     }
 
-    fun storeSchoolInfoExist(infoExist : Boolean ){
+    fun storeSchoolInfoProvided(infoExist : Boolean ){
         CoroutineScope(Dispatchers.IO).launch {
             schoolInfoUseCase.invoke(infoExist)
         }

--- a/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/viewmodel/SignUpViewModel.kt
+++ b/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/viewmodel/SignUpViewModel.kt
@@ -1,6 +1,7 @@
 package com.moneymong.moneymong.feature.sign.viewmodel
 
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.lifecycle.viewModelScope
 import com.moneymong.moneymong.common.base.BaseViewModel
 import com.moneymong.moneymong.domain.usecase.signup.SchoolInfoUseCase
 import com.moneymong.moneymong.domain.usecase.signup.UnivUseCase
@@ -63,7 +64,7 @@ class SignUpViewModel @Inject constructor(
     }
 
     fun storeSchoolInfoProvided(infoExist : Boolean ){
-        CoroutineScope(Dispatchers.IO).launch {
+        viewModelScope.launch {
             schoolInfoUseCase.invoke(infoExist)
         }
     }

--- a/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/viewmodel/SignUpViewModel.kt
+++ b/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/viewmodel/SignUpViewModel.kt
@@ -23,7 +23,7 @@ class SignUpViewModel @Inject constructor(
     private val univUseCase: UnivUseCase,
     private val schoolInfoUseCase : SchoolInfoUseCase,
 ) : BaseViewModel<SignUpState, SignUpSideEffect>(SignUpState()) {
-    fun createUniv(universityName: String, grade: Int) = intent {
+    fun createUniv(universityName: String?, grade: Int?) = intent {
         val body = UnivRequest(universityName, grade)
         univUseCase.createUniv(body)
             .onSuccess {

--- a/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/viewmodel/SplashViewModel.kt
+++ b/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/viewmodel/SplashViewModel.kt
@@ -28,8 +28,8 @@ class SplashViewModel @Inject constructor(
     fun checkTokenValidity() = intent {
         tokenUseCase.getDataStoreInfo()
             .onSuccess {
-                Log.d("Splash", "${it.accessToken}, ${it.schoolInfoExist}")
-                if (it.accessToken.isNotEmpty() && it.schoolInfoExist) {
+                Log.d("Splash", "${it.accessToken}, ${it.schoolInfoProvided}")
+                if (it.accessToken.isNotEmpty() && it.schoolInfoProvided) {
                     reduce {
                         state.copy(
                             isTokenValid = true


### PR DESCRIPTION
## 요약
회원가입 시 대학정보 없음 로직을 추가 구현하였습니다🫠

## 작업내용
|회원가입 (대학 정보 없음) | 
|:----:|
| [회원가입 동영상](https://github.com/user-attachments/assets/e5371ec5-2110-403e-b1ee-6495a19471b6) | 

## 기타
- 대학정보없음 요건 추가로 schoolInfoExist라는 네이밍으로 판별하기 어려워 **schoolInfoProvided**라는 네이밍으로 변경하였습니다. 
- 추후 서버에서  schoolInfoExist 필드는 삭제 예정이라 **schoolInfoProvided** 필드로 로직을 변경하였습니다. 
- `TokenRequest(type.name, accessToken, "", "")` "" 값은 ios 로그인을 위하여 있는 형식이므로 빈 문자열로 요청 보냅니다. 