### PR TITLE
Moneymong 524 소속 검색 기능

### DIFF
--- a/app/src/main/java/com/moneymong/moneymong/MainViewModel.kt
+++ b/app/src/main/java/com/moneymong/moneymong/MainViewModel.kt
@@ -13,10 +13,8 @@ class MainViewModel @Inject constructor(
 ) : BaseViewModel<MainState, MainSideEffect>(MainState()) {
 
     fun checkShouldUpdate(version: String) = intent {
-        val shouldUpdate =
-            checkVersionUpdateUseCase(version = version).isFailure
-        reduce {
-            state.copy(shouldUpdate = shouldUpdate)
-        }
+        checkVersionUpdateUseCase(version = version)
+            .onSuccess { reduce { state.copy(shouldUpdate = false) } }
+            .onFailure { reduce { state.copy(shouldUpdate = it.message?.contains("업데이트") == true) } }
     }
 }

--- a/core/network/src/main/java/com/moneymong/moneymong/network/api/AgencyApi.kt
+++ b/core/network/src/main/java/com/moneymong/moneymong/network/api/AgencyApi.kt
@@ -1,16 +1,16 @@
 package com.moneymong.moneymong.network.api
 
-import com.moneymong.moneymong.model.agency.AgencyJoinRequest
-import com.moneymong.moneymong.model.agency.AgencyRegisterRequest
 import com.moneymong.moneymong.model.agency.AgenciesGetResponse
+import com.moneymong.moneymong.model.agency.AgencyGetResponse
+import com.moneymong.moneymong.model.agency.AgencyJoinRequest
 import com.moneymong.moneymong.model.agency.AgencyJoinResponse
+import com.moneymong.moneymong.model.agency.AgencyRegisterRequest
 import com.moneymong.moneymong.model.agency.MyAgencyResponse
 import com.moneymong.moneymong.model.agency.RegisterAgencyResponse
 import com.moneymong.moneymong.model.member.InvitationCodeResponse
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
-import retrofit2.http.Header
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -32,6 +32,11 @@ interface AgencyApi {
 
     @GET("api/v1/agencies/me")
     suspend fun fetchMyAgencyList(): Result<List<MyAgencyResponse>>
+
+    @GET("api/v1/agencies/search")
+    suspend fun fetchAgencyByName(
+        @Query("keyword") name: String
+    ): Result<List<AgencyGetResponse>>
 
     // POST
     @POST("/api/v1/agencies/{agencyId}/invitation-code")
@@ -55,5 +60,5 @@ interface AgencyApi {
     @DELETE("api/v1/agencies/{agencyId}")
     suspend fun deleteAgency(
         @Path("agencyId") agencyId: Int
-    ) : Result<Unit>
+    ): Result<Unit>
 }

--- a/core/network/src/main/java/com/moneymong/moneymong/network/util/MoneyMongTokenAuthenticator.kt
+++ b/core/network/src/main/java/com/moneymong/moneymong/network/util/MoneyMongTokenAuthenticator.kt
@@ -37,14 +37,10 @@ class MoneyMongTokenAuthenticator @Inject constructor(
                             }
                         }
                         .onFailure {
-                            runBlocking {
-                                tokenRepository.notifyTokenUpdateFailed(true)
-                            }
+                            tokenRepository.notifyTokenUpdateFailed(true)
                         }
                 }.onFailure {
-                    runBlocking {
-                        tokenRepository.notifyTokenUpdateFailed(true)
-                    }
+                    tokenRepository.notifyTokenUpdateFailed(true)
                 }
                 newRequest
             }

--- a/data/src/main/java/com/moneymong/moneymong/data/datasource/agency/AgencyRemoteDataSource.kt
+++ b/data/src/main/java/com/moneymong/moneymong/data/datasource/agency/AgencyRemoteDataSource.kt
@@ -1,9 +1,10 @@
 package com.moneymong.moneymong.data.datasource.agency
 
-import com.moneymong.moneymong.model.agency.AgencyJoinRequest
-import com.moneymong.moneymong.model.agency.AgencyRegisterRequest
-import com.moneymong.moneymong.model.agency.AgencyJoinResponse
 import com.moneymong.moneymong.model.agency.AgenciesGetResponse
+import com.moneymong.moneymong.model.agency.AgencyGetResponse
+import com.moneymong.moneymong.model.agency.AgencyJoinRequest
+import com.moneymong.moneymong.model.agency.AgencyJoinResponse
+import com.moneymong.moneymong.model.agency.AgencyRegisterRequest
 import com.moneymong.moneymong.model.agency.MyAgencyResponse
 import com.moneymong.moneymong.model.agency.RegisterAgencyResponse
 
@@ -11,5 +12,6 @@ interface AgencyRemoteDataSource {
     suspend fun registerAgency(request: AgencyRegisterRequest): Result<RegisterAgencyResponse>
     suspend fun getAgencies(page: Int, size: Int): Result<AgenciesGetResponse>
     suspend fun fetchMyAgencyList(): Result<List<MyAgencyResponse>>
+    suspend fun fetchAgencyByName(agencyName: String): Result<List<AgencyGetResponse>>
     suspend fun agencyCodeNumbers(agencyId : Long, data: AgencyJoinRequest) : Result<AgencyJoinResponse>
 }

--- a/data/src/main/java/com/moneymong/moneymong/data/datasource/agency/AgencyRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/moneymong/moneymong/data/datasource/agency/AgencyRemoteDataSourceImpl.kt
@@ -1,12 +1,13 @@
 package com.moneymong.moneymong.data.datasource.agency
 
-import com.moneymong.moneymong.network.api.AgencyApi
-import com.moneymong.moneymong.model.agency.AgencyJoinRequest
-import com.moneymong.moneymong.model.agency.AgencyRegisterRequest
 import com.moneymong.moneymong.model.agency.AgenciesGetResponse
+import com.moneymong.moneymong.model.agency.AgencyGetResponse
+import com.moneymong.moneymong.model.agency.AgencyJoinRequest
 import com.moneymong.moneymong.model.agency.AgencyJoinResponse
+import com.moneymong.moneymong.model.agency.AgencyRegisterRequest
 import com.moneymong.moneymong.model.agency.MyAgencyResponse
 import com.moneymong.moneymong.model.agency.RegisterAgencyResponse
+import com.moneymong.moneymong.network.api.AgencyApi
 import javax.inject.Inject
 
 class AgencyRemoteDataSourceImpl @Inject constructor(
@@ -23,6 +24,10 @@ class AgencyRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun fetchMyAgencyList(): Result<List<MyAgencyResponse>> {
         return agencyApi.fetchMyAgencyList()
+    }
+
+    override suspend fun fetchAgencyByName(agencyName: String): Result<List<AgencyGetResponse>> {
+        return agencyApi.fetchAgencyByName(name = agencyName)
     }
 
     override suspend fun agencyCodeNumbers(

--- a/data/src/main/java/com/moneymong/moneymong/data/datasource/agency/AgencyRemoteDataSourceMock.kt
+++ b/data/src/main/java/com/moneymong/moneymong/data/datasource/agency/AgencyRemoteDataSourceMock.kt
@@ -1,10 +1,10 @@
 package com.moneymong.moneymong.data.datasource.agency
 
-import com.moneymong.moneymong.model.agency.AgencyJoinRequest
-import com.moneymong.moneymong.model.agency.AgencyRegisterRequest
 import com.moneymong.moneymong.model.agency.AgenciesGetResponse
 import com.moneymong.moneymong.model.agency.AgencyGetResponse
+import com.moneymong.moneymong.model.agency.AgencyJoinRequest
 import com.moneymong.moneymong.model.agency.AgencyJoinResponse
+import com.moneymong.moneymong.model.agency.AgencyRegisterRequest
 import com.moneymong.moneymong.model.agency.MyAgencyResponse
 import com.moneymong.moneymong.model.agency.RegisterAgencyResponse
 import kotlinx.coroutines.delay
@@ -21,6 +21,10 @@ class AgencyRemoteDataSourceMock : AgencyRemoteDataSource {
     }
 
     override suspend fun fetchMyAgencyList(): Result<List<MyAgencyResponse>> {
+        return Result.success(emptyList())
+    }
+
+    override suspend fun fetchAgencyByName(agencyName: String): Result<List<AgencyGetResponse>> {
         return Result.success(emptyList())
     }
 

--- a/data/src/main/java/com/moneymong/moneymong/data/repository/agency/AgencyRepositoryImpl.kt
+++ b/data/src/main/java/com/moneymong/moneymong/data/repository/agency/AgencyRepositoryImpl.kt
@@ -35,6 +35,9 @@ class AgencyRepositoryImpl @Inject constructor(
     override suspend fun fetchMyAgencyList(): Result<List<MyAgencyResponse>> =
         agencyRemoteDataSource.fetchMyAgencyList()
 
+    override suspend fun fetchAgencyByName(agencyName: String): Result<List<AgencyGetResponse>> =
+        agencyRemoteDataSource.fetchAgencyByName(agencyName)
+
     override suspend fun agencyCodeNumbers(
         agencyId: Long,
         data: AgencyJoinRequest

--- a/data/src/main/java/com/moneymong/moneymong/data/repository/token/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/moneymong/moneymong/data/repository/token/TokenRepositoryImpl.kt
@@ -25,15 +25,19 @@ class TokenRepositoryImpl @Inject constructor(
         return loginLocalDataSource.getRefreshToken()
     }
 
-    override suspend fun postAccessToken(type: LoginType, accessToken: String): Result<TokenResponse> {
-        return tokenRemoteDataSource.postAccessToken(type = type, accessToken = accessToken).onSuccess {
-            loginLocalDataSource.setDataStore(
-                it.accessToken,
-                it.refreshToken,
-                it.loginSuccess,
-                it.schoolInfoProvided
-            )
-        }
+    override suspend fun postAccessToken(
+        type: LoginType,
+        accessToken: String
+    ): Result<TokenResponse> {
+        return tokenRemoteDataSource.postAccessToken(type = type, accessToken = accessToken)
+            .onSuccess {
+                loginLocalDataSource.setDataStore(
+                    it.accessToken,
+                    it.refreshToken,
+                    it.loginSuccess,
+                    it.schoolInfoProvided
+                )
+            }
     }
 
     override suspend fun getAccessToken(): Result<String> {

--- a/domain/src/main/java/com/moneymong/moneymong/domain/repository/agency/AgencyRepository.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/repository/agency/AgencyRepository.kt
@@ -13,6 +13,7 @@ interface AgencyRepository {
     suspend fun registerAgency(request: AgencyRegisterRequest): Result<RegisterAgencyResponse>
     fun getAgencies(): Flow<PagingData<AgencyGetResponse>>
     suspend fun fetchMyAgencyList(): Result<List<MyAgencyResponse>>
+    suspend fun fetchAgencyByName(agencyName: String): Result<List<AgencyGetResponse>>
     suspend fun agencyCodeNumbers(agencyId: Long, data: AgencyJoinRequest): Result<AgencyJoinResponse>
 
     suspend fun saveAgencyId(agencyId: Int)

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/agency/FetchAgenciesUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/agency/FetchAgenciesUseCase.kt
@@ -6,7 +6,7 @@ import com.moneymong.moneymong.model.agency.AgencyGetResponse
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-class GetAgenciesUseCase @Inject constructor(
+class FetchAgenciesUseCase @Inject constructor(
     private val agencyRepository: AgencyRepository
 ) {
     operator fun invoke(): Flow<PagingData<AgencyGetResponse>> {

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/agency/FetchAgencyByNameUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/agency/FetchAgencyByNameUseCase.kt
@@ -1,0 +1,42 @@
+package com.moneymong.moneymong.domain.usecase.agency
+
+import com.moneymong.moneymong.domain.repository.agency.AgencyRepository
+import com.moneymong.moneymong.model.agency.AgencyGetResponse
+import javax.inject.Inject
+
+class FetchAgencyByNameUseCase @Inject constructor(
+    private val agencyRepository: AgencyRepository,
+) {
+
+    suspend operator fun invoke(agencyName: String): Result<List<AgencyGetResponse>> {
+//        return agencyRepository.fetchAgencyBySearch()
+        return Result.success(
+            listOf(
+                AgencyGetResponse(
+                    id = 1,
+                    name = "Agency 1",
+                    headCount = 10,
+                    type = "STUDENT_COUNCIL"
+                ),
+                AgencyGetResponse(
+                    id = 2,
+                    name = "Agency 2",
+                    headCount = 20,
+                    type = "IN_SCHOOL_CLUB"
+                ),
+                AgencyGetResponse(
+                    id = 3,
+                    name = "Agency 3",
+                    headCount = 30,
+                    type = "STUDENT_COUNCIL"
+                ),
+                AgencyGetResponse(
+                    id = 4,
+                    name = "Agency 4",
+                    headCount = 40,
+                    type = "IN_SCHOOL_CLUB"
+                ),
+            )
+        )
+    }
+}

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/agency/FetchAgencyByNameUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/agency/FetchAgencyByNameUseCase.kt
@@ -9,34 +9,6 @@ class FetchAgencyByNameUseCase @Inject constructor(
 ) {
 
     suspend operator fun invoke(agencyName: String): Result<List<AgencyGetResponse>> {
-//        return agencyRepository.fetchAgencyBySearch()
-        return Result.success(
-            listOf(
-                AgencyGetResponse(
-                    id = 1,
-                    name = "Agency 1",
-                    headCount = 10,
-                    type = "STUDENT_COUNCIL"
-                ),
-                AgencyGetResponse(
-                    id = 2,
-                    name = "Agency 2",
-                    headCount = 20,
-                    type = "IN_SCHOOL_CLUB"
-                ),
-                AgencyGetResponse(
-                    id = 3,
-                    name = "Agency 3",
-                    headCount = 30,
-                    type = "STUDENT_COUNCIL"
-                ),
-                AgencyGetResponse(
-                    id = 4,
-                    name = "Agency 4",
-                    headCount = 40,
-                    type = "IN_SCHOOL_CLUB"
-                ),
-            )
-        )
+        return agencyRepository.fetchAgencyByName(agencyName = agencyName)
     }
 }

--- a/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/FetchMyInfoUseCase.kt
+++ b/domain/src/main/java/com/moneymong/moneymong/domain/usecase/user/FetchMyInfoUseCase.kt
@@ -4,7 +4,7 @@ import com.moneymong.moneymong.domain.repository.user.UserRepository
 import com.moneymong.moneymong.model.user.UserResponse
 import javax.inject.Inject
 
-class GetMyInfoUseCase @Inject constructor(
+class FetchMyInfoUseCase @Inject constructor(
     private val userRepository: UserRepository
 ) {
     suspend operator fun invoke(): Result<UserResponse> {

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchContentView.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchContentView.kt
@@ -38,6 +38,7 @@ internal fun AgencySearchContentView(
     searchedAgencies: List<Agency>,
     onClickItem: (agencyId: Long) -> Unit,
     onClickFeedbackItem: () -> Unit,
+    isSearched: Boolean,
     isLoading: Boolean,
     isError: Boolean,
     errorMessage: String,
@@ -63,7 +64,7 @@ internal fun AgencySearchContentView(
                 },
             )
 
-        searchedAgencies.isNotEmpty() ->
+        isSearched ->
             ContentViewWithAgencies(
                 modifier = modifier,
                 agencies = searchedAgencies,
@@ -124,7 +125,7 @@ private fun ContentViewWithAgencies(
     LazyColumn(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(12.dp),
-        contentPadding = PaddingValues(bottom = 4.dp)
+        contentPadding = PaddingValues(vertical = 6.dp)
     ) {
         item {
             AgencyFeedbackItem(

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchContentView.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchContentView.kt
@@ -1,0 +1,220 @@
+package com.moneymong.moneymong.feature.agency.search
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.itemKey
+import com.moneymong.moneymong.common.error.MoneyMongError
+import com.moneymong.moneymong.design_system.R
+import com.moneymong.moneymong.design_system.component.indicator.LoadingItem
+import com.moneymong.moneymong.design_system.component.indicator.LoadingScreen
+import com.moneymong.moneymong.design_system.error.ErrorItem
+import com.moneymong.moneymong.design_system.error.ErrorScreen
+import com.moneymong.moneymong.design_system.theme.Body3
+import com.moneymong.moneymong.design_system.theme.Gray07
+import com.moneymong.moneymong.feature.agency.search.item.AgencyFeedbackItem
+import com.moneymong.moneymong.feature.agency.search.item.AgencyItem
+
+@Composable
+internal fun AgencySearchContentView(
+    modifier: Modifier = Modifier,
+    pagingItems: LazyPagingItems<Agency>,
+    searchedAgencies: List<Agency>,
+    onClickItem: (agencyId: Long) -> Unit,
+    onClickFeedbackItem: () -> Unit,
+    isLoading: Boolean,
+    isError: Boolean,
+    errorMessage: String,
+    onRetry: () -> Unit,
+) {
+    val contentLoading = pagingItems.loadState.refresh is LoadState.Loading || isLoading
+    val contentError = pagingItems.loadState.refresh is LoadState.Error || isError
+    val contentErrorMessage = errorMessage.ifEmpty {
+        (pagingItems.loadState.refresh as? LoadState.Error)?.error?.message
+            ?: MoneyMongError.UnExpectedError.message
+    }
+
+    when {
+        contentLoading -> LoadingScreen(modifier = modifier.fillMaxSize())
+
+        contentError ->
+            ErrorScreen(
+                modifier = modifier.fillMaxSize(),
+                message = contentErrorMessage,
+                onRetry = {
+                    pagingItems.retry()
+                    onRetry()
+                },
+            )
+
+        searchedAgencies.isNotEmpty() ->
+            ContentViewWithAgencies(
+                modifier = modifier,
+                agencies = searchedAgencies,
+                onClickItem = onClickItem,
+                onClickFeedbackItem = onClickFeedbackItem
+            )
+
+        pagingItems.itemCount == 0 ->
+            ContentViewWithoutAgencies(
+                modifier = modifier,
+                pagingItems = pagingItems,
+                onClickFeedbackItem = onClickFeedbackItem
+            )
+
+
+        else ->
+            ContentViewWithAgencies(
+                modifier = modifier,
+                pagingItems = pagingItems,
+                onClickItem = onClickItem,
+                onClickFeedbackItem = onClickFeedbackItem
+            )
+    }
+}
+
+
+@Composable
+private fun ContentViewWithAgencies(
+    modifier: Modifier = Modifier,
+    agencies: List<Agency>,
+    onClickItem: (agencyId: Long) -> Unit,
+    onClickFeedbackItem: () -> Unit
+) {
+    LazyColumn(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        contentPadding = PaddingValues(vertical = 6.dp)
+    ) {
+        item {
+            AgencyFeedbackItem(onClick = onClickFeedbackItem)
+        }
+        items(count = agencies.size, key = { agencies[it].id }) {
+            AgencyItem(
+                agency = agencies[it],
+                onClick = { onClickItem(agencies[it].id) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ContentViewWithAgencies(
+    modifier: Modifier = Modifier,
+    pagingItems: LazyPagingItems<Agency>,
+    onClickItem: (agencyId: Long) -> Unit,
+    onClickFeedbackItem: () -> Unit
+) {
+    LazyColumn(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        contentPadding = PaddingValues(bottom = 4.dp)
+    ) {
+        item {
+            AgencyFeedbackItem(
+                onClick = onClickFeedbackItem
+            )
+        }
+        items(
+            count = pagingItems.itemCount, key = pagingItems.itemKey { it.id }
+        ) {
+            pagingItems[it]?.let { agency ->
+                AgencyItem(
+                    agency = agency,
+                    onClick = { onClickItem(agency.id) }
+                )
+            }
+        }
+
+        when (pagingItems.loadState.source.append) {
+            is LoadState.Loading -> {
+                item {
+                    LoadingItem(modifier = Modifier.fillMaxWidth())
+                }
+            }
+
+            is LoadState.Error -> {
+                val e = pagingItems.loadState.source.append as LoadState.Error
+                item {
+                    ErrorItem(
+                        modifier = Modifier.fillMaxWidth(),
+                        message = "${e.error.message}",
+                        onRetry = pagingItems::retry
+                    )
+                }
+            }
+
+            is LoadState.NotLoading -> Unit
+        }
+    }
+}
+
+@Composable
+private fun ContentViewWithoutAgencies(
+    modifier: Modifier = Modifier,
+    pagingItems: LazyPagingItems<Agency>,
+    onClickFeedbackItem: () -> Unit
+) {
+
+    when (pagingItems.loadState.refresh) {
+        is LoadState.Loading -> {
+            LoadingScreen(modifier = modifier.fillMaxSize())
+        }
+
+        is LoadState.Error -> {
+            val e = pagingItems.loadState.refresh as LoadState.Error
+            ErrorScreen(
+                modifier = modifier.fillMaxSize(),
+                message = "${e.error.message}",
+                onRetry = pagingItems::retry
+            )
+        }
+
+        is LoadState.NotLoading -> {
+            Box(modifier = Modifier.fillMaxSize()) {
+                AgencyFeedbackItem(
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .padding(top = 10.dp),
+                    onClick = onClickFeedbackItem
+                )
+                Column(
+                    modifier = modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(
+                        space = 4.dp,
+                        alignment = Alignment.CenterVertically
+                    ),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Image(
+                        modifier = Modifier.size(size = 80.dp),
+                        painter = painterResource(id = R.drawable.img_agency),
+                        contentDescription = "agency image",
+                    )
+                    Text(
+                        text = "아직 등록된 소속이 없어요\n하단 버튼을 통해 등록해보세요",
+                        textAlign = TextAlign.Center,
+                        color = Gray07,
+                        style = Body3
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
@@ -98,7 +98,9 @@ fun AgencySearchScreen(
             modifier = Modifier.fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            AgencySearchTopBar()
+            AgencySearchTopBar(
+                onSearchIconClick = {}
+            )
             AgencySearchContentView(
                 modifier = Modifier.weight(1f),
                 pagingItems = pagingItems,

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
@@ -100,7 +100,8 @@ fun AgencySearchScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             AgencySearchTopBar(
-                onSearchIconClick = viewModel::toggleVisibilitySearchBar
+                onSearchIconClick = viewModel::toggleVisibilitySearchBar,
+                visibleSearchIcon = state.visibleSearchBar.not()
             )
             if (state.visibleSearchBar) {
                 AgencySearchBar(

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
@@ -5,21 +5,14 @@ import android.net.Uri
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateIntAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -29,34 +22,21 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.LoadState
-import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
-import androidx.paging.compose.itemKey
-import com.moneymong.moneymong.common.error.MoneyMongError
 import com.moneymong.moneymong.design_system.R
 import com.moneymong.moneymong.design_system.component.button.MDSFloatingActionButton
-import com.moneymong.moneymong.design_system.component.indicator.LoadingItem
-import com.moneymong.moneymong.design_system.component.indicator.LoadingScreen
 import com.moneymong.moneymong.design_system.component.tooltip.MDSToolTip
 import com.moneymong.moneymong.design_system.component.tooltip.MDSToolTipPosition
 import com.moneymong.moneymong.design_system.error.ErrorDialog
-import com.moneymong.moneymong.design_system.error.ErrorItem
-import com.moneymong.moneymong.design_system.error.ErrorScreen
-import com.moneymong.moneymong.design_system.theme.Body3
 import com.moneymong.moneymong.design_system.theme.Gray01
-import com.moneymong.moneymong.design_system.theme.Gray07
 import com.moneymong.moneymong.design_system.theme.MMHorizontalSpacing
 import com.moneymong.moneymong.design_system.theme.Red03
 import com.moneymong.moneymong.feature.agency.search.component.AgencySearchTopBar
 import com.moneymong.moneymong.feature.agency.search.component.searchbar.AgencySearchBar
-import com.moneymong.moneymong.feature.agency.search.item.AgencyFeedbackItem
-import com.moneymong.moneymong.feature.agency.search.item.AgencyItem
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
@@ -168,194 +148,6 @@ fun AgencySearchScreen(
                 iconResource = R.drawable.ic_plus_default,
                 containerColor = Red03
             )
-        }
-    }
-}
-
-@Composable
-private fun AgencySearchContentView(
-    modifier: Modifier = Modifier,
-    pagingItems: LazyPagingItems<Agency>,
-    searchedAgencies: List<Agency>,
-    onClickItem: (agencyId: Long) -> Unit,
-    onClickFeedbackItem: () -> Unit,
-    isLoading: Boolean,
-    isError: Boolean,
-    errorMessage: String,
-    onRetry: () -> Unit,
-) {
-    val contentLoading = pagingItems.loadState.refresh is LoadState.Loading || isLoading
-    val contentError = pagingItems.loadState.refresh is LoadState.Error || isError
-    val contentErrorMessage = errorMessage.ifEmpty {
-        (pagingItems.loadState.refresh as? LoadState.Error)?.error?.message
-            ?: MoneyMongError.UnExpectedError.message
-    }
-
-    when {
-        contentLoading -> LoadingScreen(modifier = modifier.fillMaxSize())
-
-        contentError ->
-            ErrorScreen(
-                modifier = modifier.fillMaxSize(),
-                message = contentErrorMessage,
-                onRetry = {
-                    pagingItems.retry()
-                    onRetry()
-                },
-            )
-
-        searchedAgencies.isNotEmpty() ->
-            ContentViewWithAgencies(
-                modifier = modifier,
-                agencies = searchedAgencies,
-                onClickItem = onClickItem,
-                onClickFeedbackItem = onClickFeedbackItem
-            )
-
-        pagingItems.itemCount == 0 ->
-            ContentViewWithoutAgencies(
-                modifier = modifier,
-                pagingItems = pagingItems,
-                onClickFeedbackItem = onClickFeedbackItem
-            )
-
-
-        else ->
-            ContentViewWithAgencies(
-                modifier = modifier,
-                pagingItems = pagingItems,
-                onClickItem = onClickItem,
-                onClickFeedbackItem = onClickFeedbackItem
-            )
-    }
-}
-
-
-@Composable
-private fun ContentViewWithAgencies(
-    modifier: Modifier = Modifier,
-    agencies: List<Agency>,
-    onClickItem: (agencyId: Long) -> Unit,
-    onClickFeedbackItem: () -> Unit
-) {
-    LazyColumn(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-        contentPadding = PaddingValues(vertical = 6.dp)
-    ) {
-        item {
-            AgencyFeedbackItem(onClick = onClickFeedbackItem)
-        }
-        items(count = agencies.size, key = { agencies[it].id }) {
-            AgencyItem(
-                agency = agencies[it],
-                onClick = { onClickItem(agencies[it].id) }
-            )
-        }
-    }
-}
-
-@Composable
-private fun ContentViewWithAgencies(
-    modifier: Modifier = Modifier,
-    pagingItems: LazyPagingItems<Agency>,
-    onClickItem: (agencyId: Long) -> Unit,
-    onClickFeedbackItem: () -> Unit
-) {
-    LazyColumn(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-        contentPadding = PaddingValues(bottom = 4.dp)
-    ) {
-        item {
-            AgencyFeedbackItem(
-                onClick = onClickFeedbackItem
-            )
-        }
-        items(
-            count = pagingItems.itemCount, key = pagingItems.itemKey { it.id }
-        ) {
-            pagingItems[it]?.let { agency ->
-                AgencyItem(
-                    agency = agency,
-                    onClick = { onClickItem(agency.id) }
-                )
-            }
-        }
-
-        when (pagingItems.loadState.source.append) {
-            is LoadState.Loading -> {
-                item {
-                    LoadingItem(modifier = Modifier.fillMaxWidth())
-                }
-            }
-
-            is LoadState.Error -> {
-                val e = pagingItems.loadState.source.append as LoadState.Error
-                item {
-                    ErrorItem(
-                        modifier = Modifier.fillMaxWidth(),
-                        message = "${e.error.message}",
-                        onRetry = pagingItems::retry
-                    )
-                }
-            }
-
-            is LoadState.NotLoading -> Unit
-        }
-    }
-}
-
-@Composable
-private fun ContentViewWithoutAgencies(
-    modifier: Modifier = Modifier,
-    pagingItems: LazyPagingItems<Agency>,
-    onClickFeedbackItem: () -> Unit
-) {
-
-    when (pagingItems.loadState.refresh) {
-        is LoadState.Loading -> {
-            LoadingScreen(modifier = modifier.fillMaxSize())
-        }
-
-        is LoadState.Error -> {
-            val e = pagingItems.loadState.refresh as LoadState.Error
-            ErrorScreen(
-                modifier = modifier.fillMaxSize(),
-                message = "${e.error.message}",
-                onRetry = pagingItems::retry
-            )
-        }
-
-        is LoadState.NotLoading -> {
-            Box(modifier = Modifier.fillMaxSize()) {
-                AgencyFeedbackItem(
-                    modifier = Modifier
-                        .align(Alignment.TopCenter)
-                        .padding(top = 10.dp),
-                    onClick = onClickFeedbackItem
-                )
-                Column(
-                    modifier = modifier.fillMaxSize(),
-                    verticalArrangement = Arrangement.spacedBy(
-                        space = 4.dp,
-                        alignment = Alignment.CenterVertically
-                    ),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Image(
-                        modifier = Modifier.size(size = 80.dp),
-                        painter = painterResource(id = R.drawable.img_agency),
-                        contentDescription = "agency image",
-                    )
-                    Text(
-                        text = "아직 등록된 소속이 없어요\n하단 버튼을 통해 등록해보세요",
-                        textAlign = TextAlign.Center,
-                        color = Gray07,
-                        style = Body3
-                    )
-                }
-            }
         }
     }
 }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
@@ -131,6 +131,7 @@ fun AgencySearchScreen(
                         }
                     },
                     onClickFeedbackItem = viewModel::onClickAskFeedback,
+                    isSearched = state.isSearched,
                     isLoading = state.isLoading,
                     isError = state.isError,
                     errorMessage = state.errorMessage,

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
@@ -45,6 +45,7 @@ import com.moneymong.moneymong.design_system.theme.Gray07
 import com.moneymong.moneymong.design_system.theme.MMHorizontalSpacing
 import com.moneymong.moneymong.design_system.theme.Red03
 import com.moneymong.moneymong.feature.agency.search.component.AgencySearchTopBar
+import com.moneymong.moneymong.feature.agency.search.component.searchbar.AgencySearchBar
 import com.moneymong.moneymong.feature.agency.search.item.AgencyFeedbackItem
 import com.moneymong.moneymong.feature.agency.search.item.AgencyItem
 import org.orbitmvi.orbit.compose.collectAsState
@@ -101,6 +102,13 @@ fun AgencySearchScreen(
             AgencySearchTopBar(
                 onSearchIconClick = {}
             )
+            AgencySearchBar(
+                state = state.searchTextFieldState,
+                onSearch = {},
+                onClear = viewModel::clearSearchTextField,
+                onCancel = {},
+            )
+            Spacer(modifier = Modifier.height(16.dp))
             AgencySearchContentView(
                 modifier = Modifier.weight(1f),
                 pagingItems = pagingItems,

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
@@ -103,14 +103,13 @@ fun AgencySearchScreen(
                 onSearchIconClick = viewModel::toggleVisibilitySearchBar,
                 visibleSearchIcon = state.visibleSearchBar.not()
             )
-            if (state.visibleSearchBar) {
-                AgencySearchBar(
-                    state = state.searchTextFieldState,
-                    onSearch = {},
-                    onClear = viewModel::clearSearchTextField,
-                    onCancel = viewModel::toggleVisibilitySearchBar,
-                )
-            }
+            AgencySearchBar(
+                state = state.searchTextFieldState,
+                visible = state.visibleSearchBar,
+                onSearch = {},
+                onClear = viewModel::clearSearchTextField,
+                onCancel = viewModel::toggleVisibilitySearchBar,
+            )
             Spacer(modifier = Modifier.height(16.dp))
             AgencySearchContentView(
                 modifier = Modifier.weight(1f),

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
@@ -2,6 +2,7 @@ package com.moneymong.moneymong.feature.agency.search
 
 import android.content.Intent
 import android.net.Uri
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateIntAsState
 import androidx.compose.animation.core.tween
@@ -51,6 +52,10 @@ fun AgencySearchScreen(
     val state by viewModel.collectAsState()
     val context = LocalContext.current
     val pagingItems = viewModel.agencies.collectAsLazyPagingItems()
+
+    BackHandler(enabled = state.visibleSearchBar) {
+        viewModel.toggleVisibilitySearchBar()
+    }
 
     viewModel.collectSideEffect {
         when (it) {

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
@@ -37,6 +37,7 @@ import com.moneymong.moneymong.design_system.theme.MMHorizontalSpacing
 import com.moneymong.moneymong.design_system.theme.Red03
 import com.moneymong.moneymong.feature.agency.search.component.AgencySearchTopBar
 import com.moneymong.moneymong.feature.agency.search.component.searchbar.AgencySearchBar
+import com.moneymong.moneymong.ui.pxToDp
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
@@ -112,7 +113,9 @@ fun AgencySearchScreen(
                     onCancel = viewModel::toggleVisibilitySearchBar,
                 )
                 AgencySearchContentView(
-                    modifier = Modifier.offset { IntOffset(x = 0, y = offsetY) },
+                    modifier = Modifier
+                        .offset { IntOffset(x = 0, y = offsetY) }
+                        .padding(bottom = offsetY.pxToDp),
                     pagingItems = pagingItems,
                     searchedAgencies = state.searchedAgencies,
                     onClickItem = { agencyId ->

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
@@ -122,7 +122,6 @@ fun AgencySearchScreen(
                 onSearchIconClick = viewModel::toggleVisibilitySearchBar,
                 visibleSearchIcon = state.visibleSearchBar.not()
             )
-            Spacer(modifier = Modifier.height(4.dp))
             Box(modifier = Modifier.fillMaxSize()) {
                 AgencySearchBar(
                     modifier = Modifier.onSizeChanged { searchBarHeight = it.height },
@@ -242,7 +241,7 @@ private fun ContentViewWithAgencies(
     LazyColumn(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(12.dp),
-        contentPadding = PaddingValues(bottom = 4.dp)
+        contentPadding = PaddingValues(vertical = 6.dp)
     ) {
         item {
             AgencyFeedbackItem(onClick = onClickFeedbackItem)

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchScreen.kt
@@ -100,14 +100,16 @@ fun AgencySearchScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             AgencySearchTopBar(
-                onSearchIconClick = {}
+                onSearchIconClick = viewModel::toggleVisibilitySearchBar
             )
-            AgencySearchBar(
-                state = state.searchTextFieldState,
-                onSearch = {},
-                onClear = viewModel::clearSearchTextField,
-                onCancel = {},
-            )
+            if (state.visibleSearchBar) {
+                AgencySearchBar(
+                    state = state.searchTextFieldState,
+                    onSearch = {},
+                    onClear = viewModel::clearSearchTextField,
+                    onCancel = viewModel::toggleVisibilitySearchBar,
+                )
+            }
             Spacer(modifier = Modifier.height(16.dp))
             AgencySearchContentView(
                 modifier = Modifier.weight(1f),

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchState.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchState.kt
@@ -10,7 +10,8 @@ data class AgencySearchState(
     val errorMessage: String = "",
     val visibleWarningDialog: Boolean = false,
     val isUniversityStudent: Boolean = false,
-    val searchTextFieldState: TextFieldState = TextFieldState()
+    val visibleSearchBar: Boolean = false,
+    val searchTextFieldState: TextFieldState = TextFieldState(),
 ) : State {
 
     val joinedAgenciesIds: List<Long>

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchState.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchState.kt
@@ -6,6 +6,7 @@ import com.moneymong.moneymong.common.base.State
 data class AgencySearchState(
     val joinedAgencies: List<Agency> = emptyList(),
     val searchedAgencies: List<Agency> = emptyList(),
+    val isSearched: Boolean = false,
     val isLoading: Boolean = false,
     val isError: Boolean = false,
     val errorMessage: String = "",

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchState.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchState.kt
@@ -5,6 +5,7 @@ import com.moneymong.moneymong.common.base.State
 
 data class AgencySearchState(
     val joinedAgencies: List<Agency> = emptyList(),
+    val searchedAgencies: List<Agency> = emptyList(),
     val isLoading: Boolean = false,
     val isError: Boolean = false,
     val errorMessage: String = "",

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchState.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchState.kt
@@ -1,5 +1,6 @@
 package com.moneymong.moneymong.feature.agency.search
 
+import androidx.compose.foundation.text.input.TextFieldState
 import com.moneymong.moneymong.common.base.State
 
 data class AgencySearchState(
@@ -8,7 +9,8 @@ data class AgencySearchState(
     val isError: Boolean = false,
     val errorMessage: String = "",
     val visibleWarningDialog: Boolean = false,
-    val isUniversityStudent: Boolean = false
+    val isUniversityStudent: Boolean = false,
+    val searchTextFieldState: TextFieldState = TextFieldState()
 ) : State {
 
     val joinedAgenciesIds: List<Long>

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchViewModel.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchViewModel.kt
@@ -85,9 +85,46 @@ class AgencySearchViewModel @Inject constructor(
         }
     }
 
-    fun toggleVisibilitySearchBar() = intent {
+    fun searchAgency() = intent {
         reduce {
-            state.copy(visibleSearchBar = state.visibleSearchBar.not())
+            state.copy(
+                isLoading = true,
+                isError = false
+            )
+        }
+        fetchAgencyByNameUseCase(agencyName = state.searchTextFieldState.text.toString())
+            .onSuccess { agencies ->
+                reduce {
+                    state.copy(
+                        isLoading = false,
+                        searchedAgencies = agencies.map { agencyResponse -> agencyResponse.toAgency() }
+                    )
+                }
+            }.onFailure {
+                reduce {
+                    state.copy(
+                        isLoading = false,
+                        isError = true,
+                        errorMessage = it.message ?: MoneyMongError.UnExpectedError.message
+                    )
+                }
+            }
+    }
+
+    fun toggleVisibilitySearchBar() = intent {
+        if (state.visibleSearchBar) {
+            reduce {
+                state.copy(
+                    visibleSearchBar = state.visibleSearchBar.not(),
+                    searchedAgencies = emptyList()
+                ).also {
+                    clearSearchTextField()
+                }
+            }
+        } else {
+            reduce {
+                state.copy(visibleSearchBar = state.visibleSearchBar.not())
+            }
         }
     }
 

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchViewModel.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchViewModel.kt
@@ -85,6 +85,12 @@ class AgencySearchViewModel @Inject constructor(
         }
     }
 
+    fun toggleVisibilitySearchBar() = intent {
+        reduce {
+            state.copy(visibleSearchBar = state.visibleSearchBar.not())
+        }
+    }
+
     fun clearSearchTextField() = intent {
         state.searchTextFieldState.clearText()
     }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchViewModel.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchViewModel.kt
@@ -108,6 +108,10 @@ class AgencySearchViewModel @Inject constructor(
                         errorMessage = it.message ?: MoneyMongError.UnExpectedError.message
                     )
                 }
+            }.also {
+                reduce {
+                    state.copy(isSearched = true)
+                }
             }
     }
 
@@ -115,15 +119,16 @@ class AgencySearchViewModel @Inject constructor(
         if (state.visibleSearchBar) {
             reduce {
                 state.copy(
-                    visibleSearchBar = state.visibleSearchBar.not(),
-                    searchedAgencies = emptyList()
+                    visibleSearchBar = false,
+                    searchedAgencies = emptyList(),
+                    isSearched = false
                 ).also {
                     clearSearchTextField()
                 }
             }
         } else {
             reduce {
-                state.copy(visibleSearchBar = state.visibleSearchBar.not())
+                state.copy(visibleSearchBar = true)
             }
         }
     }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchViewModel.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchViewModel.kt
@@ -1,5 +1,6 @@
 package com.moneymong.moneymong.feature.agency.search
 
+import androidx.compose.foundation.text.input.clearText
 import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import androidx.paging.map
@@ -82,6 +83,10 @@ class AgencySearchViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    fun clearSearchTextField() = intent {
+        state.searchTextFieldState.clearText()
     }
 
     fun changeVisibleWarningDialog(visible: Boolean) = intent {

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchViewModel.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/AgencySearchViewModel.kt
@@ -5,8 +5,9 @@ import androidx.paging.cachedIn
 import androidx.paging.map
 import com.moneymong.moneymong.common.base.BaseViewModel
 import com.moneymong.moneymong.common.error.MoneyMongError
+import com.moneymong.moneymong.domain.usecase.agency.FetchAgenciesUseCase
+import com.moneymong.moneymong.domain.usecase.agency.FetchAgencyByNameUseCase
 import com.moneymong.moneymong.domain.usecase.agency.FetchMyAgencyListUseCase
-import com.moneymong.moneymong.domain.usecase.agency.GetAgenciesUseCase
 import com.moneymong.moneymong.domain.usecase.university.FetchMyUniversityUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
@@ -19,9 +20,10 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AgencySearchViewModel @Inject constructor(
-    getAgenciesUseCase: GetAgenciesUseCase,
+    fetchAgenciesUseCase: FetchAgenciesUseCase,
     private val fetchMyAgencyListUseCase: FetchMyAgencyListUseCase,
-    private val fetchMyUniversityUseCase: FetchMyUniversityUseCase
+    private val fetchMyUniversityUseCase: FetchMyUniversityUseCase,
+    private val fetchAgencyByNameUseCase: FetchAgencyByNameUseCase,
 ) : BaseViewModel<AgencySearchState, AgencySearchSideEffect>(AgencySearchState()) {
 
     fun navigateToRegister() = intent {
@@ -31,7 +33,7 @@ class AgencySearchViewModel @Inject constructor(
     fun navigateToJoin(agencyId: Long) =
         eventEmit(sideEffect = AgencySearchSideEffect.NavigateToAgencyJoin(agencyId))
 
-    val agencies = getAgenciesUseCase().map { pagingData ->
+    val agencies = fetchAgenciesUseCase().map { pagingData ->
         pagingData.map {
             it.toAgency()
         }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/AgencySearchTopBar.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/AgencySearchTopBar.kt
@@ -1,5 +1,10 @@
 package com.moneymong.moneymong.feature.agency.search.component
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -21,32 +26,52 @@ import com.moneymong.moneymong.design_system.R as MDSR
 @Composable
 internal fun AgencySearchTopBar(
     modifier: Modifier = Modifier,
-    onSearchIconClick: () -> Unit
+    onSearchIconClick: () -> Unit,
+    visibleSearchIcon: Boolean,
 ) {
     Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(vertical = 16.dp),
+        modifier = modifier.fillMaxWidth()
     ) {
         Text(
-            modifier = Modifier.align(Alignment.Center),
+            modifier = Modifier
+                .align(Alignment.Center)
+                .padding(vertical = 16.dp),
             text = "소속 찾기",
             color = Gray10,
             style = Heading1
         )
-        Icon(
-            modifier = Modifier
-                .size(24.dp)
-                .align(Alignment.CenterEnd)
-                .noRippleClickable { onSearchIconClick() },
-            imageVector = ImageVector.vectorResource(id = MDSR.drawable.ic_search),
-            contentDescription = "검색",
-        )
+        AnimatedVisibility(
+            modifier = Modifier.align(Alignment.CenterEnd),
+            visible = visibleSearchIcon,
+            enter = fadeIn(
+                animationSpec = tween(
+                    durationMillis = 300,
+                    easing = FastOutSlowInEasing
+                )
+            ),
+            exit = fadeOut(
+                animationSpec = tween(
+                    durationMillis = 300,
+                    easing = FastOutSlowInEasing
+                )
+            )
+        ) {
+            Icon(
+                modifier = Modifier
+                    .size(24.dp)
+                    .noRippleClickable { onSearchIconClick() },
+                imageVector = ImageVector.vectorResource(id = MDSR.drawable.ic_search),
+                contentDescription = "검색",
+            )
+        }
     }
 }
 
 @Preview
 @Composable
 private fun AgencySearchTopBarPreview() {
-    AgencySearchTopBar(onSearchIconClick = {})
+    AgencySearchTopBar(
+        onSearchIconClick = {},
+        visibleSearchIcon = true
+    )
 }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/AgencySearchTopBar.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/AgencySearchTopBar.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.moneymong.moneymong.common.ui.noRippleClickable
 import com.moneymong.moneymong.design_system.theme.Gray10
 import com.moneymong.moneymong.design_system.theme.Heading1
 import com.moneymong.moneymong.design_system.R as MDSR
@@ -36,7 +37,8 @@ internal fun AgencySearchTopBar(
         Icon(
             modifier = Modifier
                 .size(24.dp)
-                .align(Alignment.CenterEnd),
+                .align(Alignment.CenterEnd)
+                .noRippleClickable { onSearchIconClick() },
             imageVector = ImageVector.vectorResource(id = MDSR.drawable.ic_search),
             contentDescription = "검색",
         )

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/AgencySearchTopBar.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/AgencySearchTopBar.kt
@@ -29,6 +29,9 @@ internal fun AgencySearchTopBar(
     onSearchIconClick: () -> Unit,
     visibleSearchIcon: Boolean,
 ) {
+    val animationSpec = tween<Float>(
+        durationMillis = 300, easing = FastOutSlowInEasing
+    )
     Box(
         modifier = modifier.fillMaxWidth()
     ) {
@@ -43,18 +46,8 @@ internal fun AgencySearchTopBar(
         AnimatedVisibility(
             modifier = Modifier.align(Alignment.CenterEnd),
             visible = visibleSearchIcon,
-            enter = fadeIn(
-                animationSpec = tween(
-                    durationMillis = 300,
-                    easing = FastOutSlowInEasing
-                )
-            ),
-            exit = fadeOut(
-                animationSpec = tween(
-                    durationMillis = 300,
-                    easing = FastOutSlowInEasing
-                )
-            )
+            enter = fadeIn(animationSpec = animationSpec),
+            exit = fadeOut(animationSpec = animationSpec)
         ) {
             Icon(
                 modifier = Modifier

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/AgencySearchTopBar.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/AgencySearchTopBar.kt
@@ -1,21 +1,50 @@
 package com.moneymong.moneymong.feature.agency.search.component
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.moneymong.moneymong.design_system.theme.Gray10
 import com.moneymong.moneymong.design_system.theme.Heading1
+import com.moneymong.moneymong.design_system.R as MDSR
 
 @Composable
-fun AgencySearchTopBar(
+internal fun AgencySearchTopBar(
     modifier: Modifier = Modifier,
+    onSearchIconClick: () -> Unit
 ) {
-    Text(
-        modifier = modifier.padding(vertical = 16.dp),
-        text = "소속 찾기",
-        color = Gray10,
-        style = Heading1
-    )
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 16.dp),
+    ) {
+        Text(
+            modifier = Modifier.align(Alignment.Center),
+            text = "소속 찾기",
+            color = Gray10,
+            style = Heading1
+        )
+        Icon(
+            modifier = Modifier
+                .size(24.dp)
+                .align(Alignment.CenterEnd),
+            imageVector = ImageVector.vectorResource(id = MDSR.drawable.ic_search),
+            contentDescription = "검색",
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun AgencySearchTopBarPreview() {
+    AgencySearchTopBar(onSearchIconClick = {})
 }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/searchbar/AgencySearchBar.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/searchbar/AgencySearchBar.kt
@@ -5,10 +5,9 @@ import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
@@ -56,28 +55,28 @@ internal fun AgencySearchBar(
         enter = fadeIn(animationSpec = animationSpec),
         exit = fadeOut(animationSpec = animationSpec)
     ) {
-        Column {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                AgencySearchTextField(
-                    modifier = Modifier
-                        .weight(1f)
-                        .focusRequester(focusRequester),
-                    state = state,
-                    onSearch = {
-                        onSearch()
-                        focusManager.clearFocus()
-                    },
-                    onClear = onClear
-                )
-                Spacer(modifier = Modifier.width(10.dp))
-                Text(
-                    modifier = Modifier.noRippleClickable { onCancel() },
-                    text = "취소",
-                    style = Body2,
-                    color = Gray08
-                )
-            }
-            Spacer(modifier = Modifier.height(16.dp))
+        Row(
+            modifier = Modifier.padding(vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AgencySearchTextField(
+                modifier = Modifier
+                    .weight(1f)
+                    .focusRequester(focusRequester),
+                state = state,
+                onSearch = {
+                    onSearch()
+                    focusManager.clearFocus()
+                },
+                onClear = onClear
+            )
+            Spacer(modifier = Modifier.width(10.dp))
+            Text(
+                modifier = Modifier.noRippleClickable { onCancel() },
+                text = "취소",
+                style = Body2,
+                color = Gray08
+            )
         }
     }
 }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/searchbar/AgencySearchBar.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/searchbar/AgencySearchBar.kt
@@ -1,5 +1,10 @@
 package com.moneymong.moneymong.feature.agency.search.component.searchbar
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
@@ -20,27 +25,38 @@ import com.moneymong.moneymong.design_system.theme.MMTheme
 internal fun AgencySearchBar(
     modifier: Modifier = Modifier,
     state: TextFieldState,
+    visible: Boolean,
     onSearch: () -> Unit,
     onCancel: () -> Unit,
     onClear: () -> Unit
 ) {
-    Row(
+    val animationSpec = tween<Float>(
+        durationMillis = 300,
+        easing = FastOutSlowInEasing
+    )
+    AnimatedVisibility(
         modifier = modifier,
-        verticalAlignment = Alignment.CenterVertically
+        visible = visible,
+        enter = fadeIn(animationSpec = animationSpec),
+        exit = fadeOut(animationSpec = animationSpec)
     ) {
-        AgencySearchTextField(
-            modifier = Modifier.weight(1f),
-            state = state,
-            onSearch = onSearch,
-            onClear = onClear
-        )
-        Spacer(modifier = Modifier.width(10.dp))
-        Text(
-            modifier = Modifier.noRippleClickable { onCancel() },
-            text = "취소",
-            style = Body2,
-            color = Gray08
-        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AgencySearchTextField(
+                modifier = Modifier.weight(1f),
+                state = state,
+                onSearch = onSearch,
+                onClear = onClear
+            )
+            Spacer(modifier = Modifier.width(10.dp))
+            Text(
+                modifier = Modifier.noRippleClickable { onCancel() },
+                text = "취소",
+                style = Body2,
+                color = Gray08
+            )
+        }
     }
 }
 
@@ -50,6 +66,7 @@ private fun SearchBarPreview() {
     MMTheme {
         AgencySearchBar(
             state = rememberTextFieldState(),
+            visible = true,
             onSearch = {},
             onClear = {},
             onCancel = {},

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/searchbar/AgencySearchBar.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/searchbar/AgencySearchBar.kt
@@ -1,0 +1,58 @@
+package com.moneymong.moneymong.feature.agency.search.component.searchbar
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.moneymong.moneymong.common.ui.noRippleClickable
+import com.moneymong.moneymong.design_system.theme.Body2
+import com.moneymong.moneymong.design_system.theme.Gray08
+import com.moneymong.moneymong.design_system.theme.MMTheme
+
+@Composable
+internal fun AgencySearchBar(
+    modifier: Modifier = Modifier,
+    state: TextFieldState,
+    onSearch: () -> Unit,
+    onCancel: () -> Unit,
+    onClear: () -> Unit
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        AgencySearchTextField(
+            modifier = Modifier.weight(1f),
+            state = state,
+            onSearch = onSearch,
+            onClear = onClear
+        )
+        Spacer(modifier = Modifier.width(10.dp))
+        Text(
+            modifier = Modifier.noRippleClickable { onCancel() },
+            text = "취소",
+            style = Body2,
+            color = Gray08
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SearchBarPreview() {
+    MMTheme {
+        AgencySearchBar(
+            state = rememberTextFieldState(),
+            onSearch = {},
+            onClear = {},
+            onCancel = {},
+        )
+    }
+}

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/searchbar/AgencySearchBar.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/searchbar/AgencySearchBar.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.moneymong.moneymong.common.ui.noRippleClickable
@@ -37,6 +38,7 @@ internal fun AgencySearchBar(
     onClear: () -> Unit
 ) {
     val focusRequester = remember { FocusRequester() }
+    val focusManager = LocalFocusManager.current
     val animationSpec = tween<Float>(
         durationMillis = 300,
         easing = FastOutSlowInEasing
@@ -49,7 +51,7 @@ internal fun AgencySearchBar(
     }
 
     AnimatedVisibility(
-        modifier = modifier.focusRequester(focusRequester),
+        modifier = modifier,
         visible = visible,
         enter = fadeIn(animationSpec = animationSpec),
         exit = fadeOut(animationSpec = animationSpec)
@@ -57,9 +59,14 @@ internal fun AgencySearchBar(
         Column {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 AgencySearchTextField(
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier
+                        .weight(1f)
+                        .focusRequester(focusRequester),
                     state = state,
-                    onSearch = onSearch,
+                    onSearch = {
+                        onSearch()
+                        focusManager.clearFocus()
+                    },
                     onClear = onClear
                 )
                 Spacer(modifier = Modifier.width(10.dp))

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/searchbar/AgencySearchBar.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/searchbar/AgencySearchBar.kt
@@ -5,8 +5,10 @@ import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
@@ -40,22 +42,23 @@ internal fun AgencySearchBar(
         enter = fadeIn(animationSpec = animationSpec),
         exit = fadeOut(animationSpec = animationSpec)
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            AgencySearchTextField(
-                modifier = Modifier.weight(1f),
-                state = state,
-                onSearch = onSearch,
-                onClear = onClear
-            )
-            Spacer(modifier = Modifier.width(10.dp))
-            Text(
-                modifier = Modifier.noRippleClickable { onCancel() },
-                text = "취소",
-                style = Body2,
-                color = Gray08
-            )
+        Column {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                AgencySearchTextField(
+                    modifier = Modifier.weight(1f),
+                    state = state,
+                    onSearch = onSearch,
+                    onClear = onClear
+                )
+                Spacer(modifier = Modifier.width(10.dp))
+                Text(
+                    modifier = Modifier.noRippleClickable { onCancel() },
+                    text = "취소",
+                    style = Body2,
+                    color = Gray08
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp))
         }
     }
 }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/searchbar/AgencySearchBar.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/searchbar/AgencySearchBar.kt
@@ -68,7 +68,10 @@ internal fun AgencySearchBar(
                     onSearch()
                     focusManager.clearFocus()
                 },
-                onClear = onClear
+                onClear = {
+                    onClear()
+                    focusRequester.requestFocus()
+                }
             )
             Spacer(modifier = Modifier.width(10.dp))
             Text(

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/searchbar/AgencySearchBar.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/searchbar/AgencySearchBar.kt
@@ -14,8 +14,12 @@ import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.moneymong.moneymong.common.ui.noRippleClickable
@@ -32,12 +36,20 @@ internal fun AgencySearchBar(
     onCancel: () -> Unit,
     onClear: () -> Unit
 ) {
+    val focusRequester = remember { FocusRequester() }
     val animationSpec = tween<Float>(
         durationMillis = 300,
         easing = FastOutSlowInEasing
     )
+
+    LaunchedEffect(key1 = visible) {
+        if (visible) {
+            focusRequester.requestFocus()
+        }
+    }
+
     AnimatedVisibility(
-        modifier = modifier,
+        modifier = modifier.focusRequester(focusRequester),
         visible = visible,
         enter = fadeIn(animationSpec = animationSpec),
         exit = fadeOut(animationSpec = animationSpec)

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/searchbar/AgencySearchTextField.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/search/component/searchbar/AgencySearchTextField.kt
@@ -1,0 +1,93 @@
+package com.moneymong.moneymong.feature.agency.search.component.searchbar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.moneymong.moneymong.common.ui.noRippleClickable
+import com.moneymong.moneymong.design_system.theme.Blue04
+import com.moneymong.moneymong.design_system.theme.Body2
+import com.moneymong.moneymong.design_system.theme.Gray04
+import com.moneymong.moneymong.design_system.theme.Gray05
+import com.moneymong.moneymong.design_system.theme.Gray09
+import com.moneymong.moneymong.design_system.theme.MMTheme
+import com.moneymong.moneymong.design_system.theme.White
+import com.moneymong.moneymong.design_system.R as MDSR
+
+@Composable
+internal fun AgencySearchTextField(
+    modifier: Modifier = Modifier,
+    state: TextFieldState,
+    onSearch: () -> Unit,
+    onClear: () -> Unit,
+) {
+
+    BasicTextField(
+        modifier = modifier,
+        state = state,
+        keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Search),
+        onKeyboardAction = { onSearch() },
+        decorator = { innerTextField ->
+            Row(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(color = White)
+                    .border(width = 1.dp, color = Blue04, shape = RoundedCornerShape(8.dp))
+                    .padding(vertical = 10.dp, horizontal = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box {
+                    innerTextField()
+                    if (state.text.isEmpty()) {
+                        Text(
+                            text = "소속을 검색해 보세요",
+                            color = Gray05,
+                            style = Body2
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                Icon(
+                    modifier = Modifier
+                        .size(20.dp)
+                        .noRippleClickable { onClear() },
+                    imageVector = ImageVector.vectorResource(id = MDSR.drawable.ic_close_default),
+                    contentDescription = "Clear Search Text",
+                    tint = Gray04,
+                )
+            }
+        },
+        textStyle = Body2.copy(color = Gray09)
+    )
+}
+
+@Preview
+@Composable
+private fun SearchTextFieldPreview() {
+    MMTheme {
+        AgencySearchTextField(
+            state = rememberTextFieldState(),
+            onSearch = { },
+            onClear = { }
+        )
+    }
+}

--- a/feature/member/src/main/java/com/example/member/MemberViewModel.kt
+++ b/feature/member/src/main/java/com/example/member/MemberViewModel.kt
@@ -9,7 +9,7 @@ import com.moneymong.moneymong.domain.usecase.member.MemberInvitationCodeUseCase
 import com.moneymong.moneymong.domain.usecase.member.MemberListUseCase
 import com.moneymong.moneymong.domain.usecase.member.MemberReInvitationCodeUseCase
 import com.moneymong.moneymong.domain.usecase.member.UpdateMemberAuthorUseCase
-import com.moneymong.moneymong.domain.usecase.user.GetMyInfoUseCase
+import com.moneymong.moneymong.domain.usecase.user.FetchMyInfoUseCase
 import com.moneymong.moneymong.model.agency.MyAgencyResponse
 import com.moneymong.moneymong.model.member.AgencyUser
 import com.moneymong.moneymong.model.member.MemberBlockRequest
@@ -26,7 +26,7 @@ class MemberViewModel @Inject constructor(
     private val memberInvitationCodeUseCase: MemberInvitationCodeUseCase,
     private val memberReInvitationCodeUseCase: MemberReInvitationCodeUseCase,
     private val memberListUseCase: MemberListUseCase,
-    private val getMyInfoUseCase: GetMyInfoUseCase,
+    private val fetchMyInfoUseCase: FetchMyInfoUseCase,
     private val updateMemberAuthorUseCase: UpdateMemberAuthorUseCase,
     private val memberBlockUseCase: MemberBlockUseCase,
     private val fetchAgencyIdUseCase: FetchAgencyIdUseCase,
@@ -224,7 +224,7 @@ class MemberViewModel @Inject constructor(
     }
 
     fun getMyInfo() = intent {
-        getMyInfoUseCase.invoke()
+        fetchMyInfoUseCase.invoke()
             .onSuccess {
                 reduce {
                     state.copy(

--- a/feature/mymong/src/main/java/com/moneymong/moneymong/feature/mymong/main/MyMongViewModel.kt
+++ b/feature/mymong/src/main/java/com/moneymong/moneymong/feature/mymong/main/MyMongViewModel.kt
@@ -3,7 +3,7 @@ package com.moneymong.moneymong.feature.mymong.main
 import com.moneymong.moneymong.common.base.BaseViewModel
 import com.moneymong.moneymong.common.error.MoneyMongError
 import com.moneymong.moneymong.domain.usecase.agency.SaveAgencyIdUseCase
-import com.moneymong.moneymong.domain.usecase.user.GetMyInfoUseCase
+import com.moneymong.moneymong.domain.usecase.user.FetchMyInfoUseCase
 import com.moneymong.moneymong.domain.usecase.user.LogoutUseCase
 import com.moneymong.moneymong.domain.usecase.user.SaveDeniedCameraPermissionUseCase
 import com.moneymong.moneymong.domain.usecase.user.SaveUserIdUseCase
@@ -15,7 +15,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MyMongViewModel @Inject constructor(
-    private val getMyInfoUseCase: GetMyInfoUseCase,
+    private val fetchMyInfoUseCase: FetchMyInfoUseCase,
     private val logoutUseCase: LogoutUseCase,
     private val saveAgencyIdUseCase: SaveAgencyIdUseCase,
     private val saveUserIdUseCase: SaveUserIdUseCase,
@@ -42,7 +42,7 @@ class MyMongViewModel @Inject constructor(
                 isInfoError = false,
             )
         }
-        getMyInfoUseCase()
+        fetchMyInfoUseCase()
             .also {
                 reduce {
                     state.copy(isInfoLoading = false)

--- a/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/view/SearchUnivView.kt
+++ b/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/view/SearchUnivView.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -25,14 +24,15 @@ import com.moneymong.moneymong.design_system.component.textfield.util.MDSTextFie
 import com.moneymong.moneymong.design_system.theme.Body4
 import com.moneymong.moneymong.design_system.theme.Gray05
 import com.moneymong.moneymong.design_system.theme.White
-import com.moneymong.moneymong.model.sign.University
 import com.moneymong.moneymong.feature.sign.item.UnivItem
 import com.moneymong.moneymong.model.sign.UniversitiesResponse
+import com.moneymong.moneymong.model.sign.University
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.debounce
 
-@OptIn(ExperimentalComposeUiApi::class, FlowPreview::class)
+
+@OptIn(FlowPreview::class)
 @Composable
 fun SearchUnivView(
     modifier: Modifier = Modifier,
@@ -61,10 +61,9 @@ fun SearchUnivView(
             .debounce(debouncePeriod)
             .collect { query ->
                 Log.d("query", query)
-                if(query.isEmpty() && value.text.isNotEmpty()){
+                if (query.isEmpty() && value.text.isNotEmpty()) {
                     onSearchIconClicked(value.text)
-                }
-                else{
+                } else {
                     onSearchIconClicked(query)
                 }
                 isFilledChanged(false)
@@ -100,7 +99,7 @@ fun SearchUnivView(
                 if (value.text.isEmpty()) {
                     isListVisibleChanged(false)
                 } else {
-                    onSearchIconClicked(textValue.toString())
+                    onSearchIconClicked(textValue.text)
                     isFilledChanged(true)
                     isListVisibleChanged(true)
                 }

--- a/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/viewmodel/SignUpViewModel.kt
+++ b/feature/sign/src/main/java/com/moneymong/moneymong/feature/sign/viewmodel/SignUpViewModel.kt
@@ -11,8 +11,6 @@ import com.moneymong.moneymong.feature.sign.state.SignUpState
 import com.moneymong.moneymong.feature.sign.util.Grade
 import com.moneymong.moneymong.model.sign.UnivRequest
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.syntax.simple.blockingIntent
@@ -65,7 +63,7 @@ class SignUpViewModel @Inject constructor(
             }
     }
 
-    fun storeSchoolInfoProvided(infoExist : Boolean ){
+    fun storeSchoolInfoProvided(infoExist: Boolean) {
         viewModelScope.launch {
             schoolInfoUseCase.invoke(infoExist)
         }
@@ -177,5 +175,4 @@ class SignUpViewModel @Inject constructor(
             )
         }
     }
-
 }


### PR DESCRIPTION
## 요약
소속 탭에서 소속을 검색할 수 있습니다!

## 작업내용
- [x] 기능개발
- [ ] 버그개선
- [x] 리팩토링
- [ ] 핫픽스
- [ ] 빌드 파일 수정
- [ ] 기타

## 스크린샷
https://github.com/user-attachments/assets/eb54a076-24c9-427e-9b17-36f3029ab96f


## 기타
검색 바 Animation 은 `fade (in, out)` 처리하고, 
검색 바 아래 소속 목록 Animation 은 검색 바 `Height` 만큼 `animateIntAsState`를 사용해 위로 올리도록 했습니다.

- 불필요한 코드 제거 및 네이밍 통일을 위해 일부 변경했습니다!
- 대학 검색 기능에서 검색 아이콘을 눌렀을 때, 대학 목록이 사라지는 버그를 해결했습니다!

