### PR TITLE
[ID-21] 장부 선택 바텀시트 선택된 장부가 항상 보이도록 수정

### DIFF
--- a/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/view/LedgerSelectBottomSheet.kt
+++ b/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/view/LedgerSelectBottomSheet.kt
@@ -6,9 +6,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
@@ -79,8 +81,15 @@ private fun LedgerAgencySelectItems(
     var itemHeight by remember { mutableIntStateOf(0) }
     val itemSpace = 12.dp
     val maxVisibleItemCount = 3
+    val listState = rememberLazyListState()
 
-    Column(
+    LaunchedEffect(key1 = Unit) {
+        val currentAgencyIndex =
+            agencyList.indexOfFirst { it.id == currentAgencyId }.coerceAtLeast(0)
+        listState.animateScrollToItem(index = currentAgencyIndex)
+    }
+
+    LazyColumn(
         modifier = Modifier
             .height(
                 if (itemHeight > 0 && agencyList.size > maxVisibleItemCount) {
@@ -88,11 +97,11 @@ private fun LedgerAgencySelectItems(
                 } else {
                     Dp.Unspecified
                 }
-            )
-            .verticalScroll(rememberScrollState()),
+            ),
+        state = listState,
         verticalArrangement = Arrangement.spacedBy(space = itemSpace),
     ) {
-        agencyList.forEach { item ->
+        items(items = agencyList) { item ->
             LedgerAgencySelectItem(
                 modifier = Modifier.onGloballyPositioned {
                     if (itemHeight == 0) {


### PR DESCRIPTION
## 요약
장부 선택 바텀시트에서 선택된 장부가 항상 화면에 표시되도록 개선했습니다.
이전에는 최대 3개까지 보여서, 4번째 장부가 선택되었다면 사용자가 스크롤해야만 확인할 수 있었습니다.

## 작업내용
- [x] 기능개발
- [ ] 버그개선
- [ ] 리팩토링
- [ ] 핫픽스
- [ ] 빌드 파일 수정
- [ ] 기타

## 스크린샷
### 기존
https://github.com/user-attachments/assets/4d4f2954-ee62-40e8-8d9e-836ce901659f


### 변경 후
https://github.com/user-attachments/assets/85dbccfe-7309-4b39-a9e8-5c323533ea9f

