### PR TITLE
[ID - 40] 장부 온보딩 반복 노출 이슈

### DIFF
--- a/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/LedgerViewModel.kt
+++ b/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/LedgerViewModel.kt
@@ -257,7 +257,6 @@ class LedgerViewModel @Inject constructor(
 
     fun onDismissOnboarding() = intent {
         postDisplayedLedgerOnboardingUseCase(onboardingType = state.onboardingType)
-        reduce { state.copy(visibleOnboarding = false) }
     }
 
 

--- a/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/LedgerViewModel.kt
+++ b/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/LedgerViewModel.kt
@@ -55,10 +55,10 @@ class LedgerViewModel @Inject constructor(
             fetchAgencyExistLedger(),
             fetchAgencyMemberList(),
             fetchLedgerTransactionList(),
-            fetchVisibleLedgerOnboarding()
         )
 
         jobList.joinAll()
+        fetchVisibleLedgerOnboarding()
     }
 
     fun fetchDefaultInfo() = intent {


### PR DESCRIPTION
## 요약
장부 온보딩이 노출됐음에도 불구하고 이후 재노출되는 현상을 수정했습니다.

### 원인
온보딩 노출 여부를 판단하기 위해서는 onboardingType 값(운영진 or 멤버)이 필요합니다.
이 onboardingType은 memberList 값을 기반으로 설정되는데, 해당 값은 fetchAgencyMemberList 함수에서 세팅됩니다.

하지만 fetchAgencyMemberList와 온보딩 노출 여부를 결정하는 함수가 비동기로 동시에 실행되고 있어, memberList가 아직 세팅되지 않은 상태에서 잘못된 onboardingType을 참조하는 문제가 발생했었습니다.

-> 순차적으로 호출되도록 변경했습니다.

## 작업내용
- [ ] 기능개발
- [x] 버그개선
- [ ] 리팩토링
- [ ] 핫픽스
- [ ] 빌드 파일 수정
- [ ] 기타

## 스크린샷
- ui 변경은 없습니다.

## 기타
- fetchVisibleLedgerOnboarding 함수에서 dataSource 값을 관찰하고 있어서, 직접적으로 `state`값을 변경하는게 불필요하다 판단하여 해당 코드를 삭제했습니다.(2555b7234d13843390f8de0528a7485745a84eb5)
