### PR TITLE
[ID-48] 장부 생성 화면 내 장부 가입 기능 추가

### DIFF
--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/AgencyJoinScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/AgencyJoinScreen.kt
@@ -61,15 +61,18 @@ fun AgencyJoinScreen(
                     .background(White)
                     .height(44.dp),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.End
+                horizontalArrangement = if (state.isBackButton) Arrangement.Start else Arrangement.End
             ) {
+                val navigateUpIconId =
+                    if (state.isBackButton) R.drawable.ic_chevron_left else R.drawable.ic_close_default
+
                 Icon(
                     modifier = Modifier
                         .size(24.dp)
                         .noRippleClickable {
                             navigateUp()
                         },
-                    painter = painterResource(id = R.drawable.ic_close_default),
+                    painter = painterResource(id = navigateUpIconId),
                     contentDescription = null,
                     tint = Black
                 )

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/AgencyJoinState.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/AgencyJoinState.kt
@@ -8,5 +8,6 @@ data class AgencyJoinState(
     val inputCode: String = "",
     val codeAccess: Boolean = false,
     val visiblePopUpError: Boolean = false,
-    val errorPopUpMessage: String = ""
+    val errorPopUpMessage: String = "",
+    val isBackButton: Boolean = false,
 ) : State

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/AgencyJoinViewModel.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/AgencyJoinViewModel.kt
@@ -1,11 +1,13 @@
 package com.moneymong.moneymong.feature.agency.join
 
 import androidx.core.text.isDigitsOnly
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.moneymong.moneymong.android.BaseViewModel
 import com.moneymong.moneymong.domain.usecase.agency.AgencyJoinUseCase
 import com.moneymong.moneymong.domain.usecase.agency.SaveAgencyIdUseCase
 import com.moneymong.moneymong.feature.agency.join.component.CODE_MAX_SIZE
+import com.moneymong.moneymong.feature.agency.join.navigation.AgencyJoinArgs
 import com.moneymong.moneymong.model.agency.AgencyJoinRequest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -15,9 +17,11 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AgencyJoinViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
     private val agencyJoinUseCase: AgencyJoinUseCase,
     private val saveAgencyIdUseCase: SaveAgencyIdUseCase
-) : BaseViewModel<AgencyJoinState, AgencyJoinSideEffect>(AgencyJoinState()) {
+) : BaseViewModel<AgencyJoinState, AgencyJoinSideEffect>(
+    state = AgencyJoinState(isBackButton = AgencyJoinArgs(savedStateHandle).isBackButton)) {
 
     fun findLedgerByInviteCode() = intent {
         viewModelScope.launch {

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/navigation/AgencyJoinNavigation.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/join/navigation/AgencyJoinNavigation.kt
@@ -1,25 +1,45 @@
 package com.moneymong.moneymong.feature.agency.join.navigation
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.moneymong.moneymong.feature.agency.join.AgencyJoinScreen
 
 const val agencyJoinRoute = "agencyJoin_route"
+const val IS_BACK_BUTTON = "IsBackButton"
+const val agencyJoinRouteWithArgs = "$agencyJoinRoute/{${IS_BACK_BUTTON}}"
 
-fun NavController.navigateAgencyJoin(navOptions: NavOptions? = null) {
-    navigate(agencyJoinRoute, navOptions)
+fun NavController.navigateAgencyJoin(
+    navOptions: NavOptions? = null,
+    isBackButton: Boolean = false
+) {
+    navigate("${agencyJoinRoute}/${isBackButton}", navOptions)
 }
 
 fun NavGraphBuilder.agencyJoinScreen(
     navigateToComplete: () -> Unit,
     navigateUp: () -> Unit,
 ) {
-    composable(route = agencyJoinRoute) {
+    composable(
+        route = agencyJoinRouteWithArgs,
+        arguments = listOf(navArgument(IS_BACK_BUTTON) {
+            type = NavType.BoolType
+            defaultValue = false
+        })
+    ) {
         AgencyJoinScreen(
             navigateToComplete = navigateToComplete,
             navigateUp = navigateUp,
         )
     }
+}
+
+internal class AgencyJoinArgs(val isBackButton: Boolean) {
+    constructor(savedStateHandle: SavedStateHandle) : this(
+        isBackButton = checkNotNull(savedStateHandle[IS_BACK_BUTTON])
+    )
 }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/navigation/AgencyRegisterNavigation.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/navigation/AgencyRegisterNavigation.kt
@@ -1,25 +1,44 @@
 package com.moneymong.moneymong.feature.agency.navigation
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.moneymong.moneymong.feature.agency.register.AgencyRegisterScreen
 
 const val agencyRegisterRoute = "agencyRegister_route"
+const val VISIBLE_INVITE_CODE = "VisibleInviteCode"
+const val agencyRegisterRouteWithArgs = "${agencyRegisterRoute}/{${VISIBLE_INVITE_CODE}}"
 
 fun NavController.navigateAgencyRegister(
-    navOptions: NavOptions? = null
+    navOptions: NavOptions? = null,
+    visibleInviteCode: Boolean = false,
 ) {
-    navigate(agencyRegisterRoute, navOptions)
+    navigate("${agencyRegisterRoute}/${visibleInviteCode}", navOptions)
 }
 
 fun NavGraphBuilder.agencyRegisterScreen(
     navigateToLedger: () -> Unit
 ) {
     composable(
-        route = agencyRegisterRoute,
+        route = agencyRegisterRouteWithArgs,
+        arguments = listOf(navArgument(VISIBLE_INVITE_CODE) {
+            type = NavType.BoolType
+            defaultValue = false
+        })
     ) {
-        AgencyRegisterScreen(navigateToLedger = navigateToLedger,)
+        AgencyRegisterScreen(
+            navigateToLedger = navigateToLedger,
+        )
     }
+}
+
+
+internal class AgencyRegisterArgs(val visibleInviteCode: Boolean) {
+    constructor(savedStateHandle: SavedStateHandle) : this(
+        visibleInviteCode = checkNotNull(savedStateHandle[VISIBLE_INVITE_CODE])
+    )
 }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/navigation/AgencyRegisterNavigation.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/navigation/AgencyRegisterNavigation.kt
@@ -21,7 +21,8 @@ fun NavController.navigateAgencyRegister(
 }
 
 fun NavGraphBuilder.agencyRegisterScreen(
-    navigateToLedger: () -> Unit
+    navigateToLedger: () -> Unit,
+    navigateToAgencyJoin: () -> Unit,
 ) {
     composable(
         route = agencyRegisterRouteWithArgs,
@@ -32,6 +33,7 @@ fun NavGraphBuilder.agencyRegisterScreen(
     ) {
         AgencyRegisterScreen(
             navigateToLedger = navigateToLedger,
+            navigateToAgencyJoin = navigateToAgencyJoin
         )
     }
 }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterScreen.kt
@@ -116,6 +116,9 @@ fun AgencyRegisterScreen(
                 agencyName = state.agencyName,
                 onAgencyNameChange = viewModel::changeAgencyName,
                 changeNameTextFieldIsError = viewModel::changeNameTextFieldIsError,
+                // heejik: todo
+                visibleInviteCode = true,
+                onClickInviteCode = {}
             )
         }
         val canRegister = state.agencyName.text.isNotEmpty() && state.nameTextFieldIsError.not()

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterScreen.kt
@@ -116,8 +116,7 @@ fun AgencyRegisterScreen(
                 agencyName = state.agencyName,
                 onAgencyNameChange = viewModel::changeAgencyName,
                 changeNameTextFieldIsError = viewModel::changeNameTextFieldIsError,
-                // heejik: todo
-                visibleInviteCode = true,
+                visibleInviteCode = state.visibleInviteCode,
                 onClickInviteCode = {}
             )
         }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterScreen.kt
@@ -1,5 +1,6 @@
 package com.moneymong.moneymong.feature.agency.register
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Column
@@ -60,6 +61,8 @@ fun AgencyRegisterScreen(
             }
         }
     }
+
+    BackHandler(onBack = viewModel::navigateToLedger)
 
     if (state.visibleOutDialog) {
         MDSModal(

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterScreen.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterScreen.kt
@@ -42,6 +42,7 @@ fun AgencyRegisterScreen(
     modifier: Modifier = Modifier,
     viewModel: AgencyRegisterViewModel = hiltViewModel(),
     navigateToLedger: () -> Unit,
+    navigateToAgencyJoin: () -> Unit
 ) {
     val state by viewModel.collectAsState()
     val focusManager = LocalFocusManager.current
@@ -52,6 +53,10 @@ fun AgencyRegisterScreen(
             is AgencyRegisterSideEffect.NavigateToLedger -> {
                 focusManager.clearFocus()
                 navigateToLedger()
+            }
+
+            is AgencyRegisterSideEffect.NavigateToAgencyJoin -> {
+                navigateToAgencyJoin()
             }
         }
     }
@@ -117,7 +122,7 @@ fun AgencyRegisterScreen(
                 onAgencyNameChange = viewModel::changeAgencyName,
                 changeNameTextFieldIsError = viewModel::changeNameTextFieldIsError,
                 visibleInviteCode = state.visibleInviteCode,
-                onClickInviteCode = {}
+                onClickInviteCode = viewModel::navigateToAgencyJoin
             )
         }
         val canRegister = state.agencyName.text.isNotEmpty() && state.nameTextFieldIsError.not()
@@ -137,5 +142,6 @@ fun AgencyRegisterScreen(
 fun AgencyRegisterScreenPreview() {
     AgencyRegisterScreen(
         navigateToLedger = {},
+        navigateToAgencyJoin = {}
     )
 }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterSideEffect.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterSideEffect.kt
@@ -4,4 +4,6 @@ import com.moneymong.moneymong.android.SideEffect
 
 sealed interface AgencyRegisterSideEffect : SideEffect {
     data object NavigateToLedger : AgencyRegisterSideEffect
+
+    data object NavigateToAgencyJoin : AgencyRegisterSideEffect
 }

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterState.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterState.kt
@@ -11,4 +11,5 @@ data class AgencyRegisterState(
     val nameTextFieldIsError: Boolean = false,
     val visibleOutDialog: Boolean = false,
     val visibleErrorDialog: Boolean = false,
+    val visibleInviteCode: Boolean = false
 ) : State

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterViewModel.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterViewModel.kt
@@ -25,7 +25,11 @@ class AgencyRegisterViewModel @Inject constructor(
     state = AgencyRegisterState(visibleInviteCode = AgencyRegisterArgs(savedStateHandle).visibleInviteCode)
 ) {
 
-    fun navigateToLedger() = eventEmit(sideEffect = AgencyRegisterSideEffect.NavigateToLedger)
+    fun navigateToLedger() =
+        eventEmit(sideEffect = AgencyRegisterSideEffect.NavigateToLedger)
+
+    fun navigateToAgencyJoin() =
+        eventEmit(sideEffect = AgencyRegisterSideEffect.NavigateToAgencyJoin)
 
     fun registerAgency() = intent {
         registerAgencyUseCase(

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterViewModel.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/AgencyRegisterViewModel.kt
@@ -1,10 +1,12 @@
 package com.moneymong.moneymong.feature.agency.register
 
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.lifecycle.SavedStateHandle
 import com.moneymong.moneymong.android.BaseViewModel
 import com.moneymong.moneymong.common.error.MoneyMongError
 import com.moneymong.moneymong.domain.usecase.agency.RegisterAgencyUseCase
 import com.moneymong.moneymong.domain.usecase.agency.SaveAgencyIdUseCase
+import com.moneymong.moneymong.feature.agency.navigation.AgencyRegisterArgs
 import com.moneymong.moneymong.model.agency.AgencyRegisterRequest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.annotation.OrbitExperimental
@@ -16,9 +18,12 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AgencyRegisterViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
     private val registerAgencyUseCase: RegisterAgencyUseCase,
     private val saveAgencyIdUseCase: SaveAgencyIdUseCase
-) : BaseViewModel<AgencyRegisterState, AgencyRegisterSideEffect>(AgencyRegisterState()) {
+) : BaseViewModel<AgencyRegisterState, AgencyRegisterSideEffect>(
+    state = AgencyRegisterState(visibleInviteCode = AgencyRegisterArgs(savedStateHandle).visibleInviteCode)
+) {
 
     fun navigateToLedger() = eventEmit(sideEffect = AgencyRegisterSideEffect.NavigateToLedger)
 

--- a/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/view/AgencyRegisterContentView.kt
+++ b/feature/agency/src/main/java/com/moneymong/moneymong/feature/agency/register/view/AgencyRegisterContentView.kt
@@ -1,9 +1,11 @@
 package com.moneymong.moneymong.feature.agency.register.view
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -14,15 +16,18 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.moneymong.moneymong.design_system.component.textfield.MDSTextField
 import com.moneymong.moneymong.design_system.component.textfield.util.MDSTextFieldIcons
 import com.moneymong.moneymong.design_system.component.textfield.util.withRequiredMark
+import com.moneymong.moneymong.design_system.theme.Body1
 import com.moneymong.moneymong.design_system.theme.Body3
 import com.moneymong.moneymong.design_system.theme.Gray05
 import com.moneymong.moneymong.design_system.theme.Gray10
@@ -34,6 +39,8 @@ internal fun AgencyResisterContentView(
     agencyName: TextFieldValue,
     onAgencyNameChange: (TextFieldValue) -> Unit,
     changeNameTextFieldIsError: (Boolean) -> Unit,
+    visibleInviteCode: Boolean,
+    onClickInviteCode: () -> Unit
 ) {
     Column(modifier = modifier) {
         TitleView()
@@ -43,6 +50,20 @@ internal fun AgencyResisterContentView(
             onAgencyNameChange = onAgencyNameChange,
             changeIsError = changeNameTextFieldIsError
         )
+        Spacer(modifier = Modifier.height(7.dp))
+
+        if (visibleInviteCode) {
+            Text(
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .clickable(onClick = onClickInviteCode)
+                    .padding(8.dp),
+                text = "초대코드를 받았어요 >",
+                style = Body1,
+                color = Gray05,
+                textDecoration = TextDecoration.Underline
+            )
+        }
     }
 }
 
@@ -119,5 +140,7 @@ private fun AgencyResisterContentViewPreview() {
         agencyName = TextFieldValue("동아리"),
         onAgencyNameChange = {},
         changeNameTextFieldIsError = {},
+        visibleInviteCode = true,
+        onClickInviteCode = {}
     )
 }

--- a/feature/home/src/main/java/com/moneymong/moneymong/home/HomeBottomTabs.kt
+++ b/feature/home/src/main/java/com/moneymong/moneymong/home/HomeBottomTabs.kt
@@ -2,7 +2,6 @@ package com.moneymong.moneymong.home
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import com.moneymong.moneymong.feature.agency.navigation.agencyRoute
 import com.moneymong.moneymong.feature.mymong.navigation.mymongRoute
 import com.moneymong.moneymong.ledger.navigation.ledgerRouteWithArgs
 

--- a/feature/home/src/main/java/com/moneymong/moneymong/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/moneymong/moneymong/home/HomeScreen.kt
@@ -174,7 +174,7 @@ fun HomeScreen(
 
                 agencyRegisterScreen(
                     navigateToLedger = homeNavController::navigateLedger,
-                    navigateToAgencyJoin = homeNavController::navigateAgencyJoin
+                    navigateToAgencyJoin = { homeNavController.navigateAgencyJoin(isBackButton = true) }
                 )
 
                 agencyRegisterCompleteScreen(

--- a/feature/home/src/main/java/com/moneymong/moneymong/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/moneymong/moneymong/home/HomeScreen.kt
@@ -173,7 +173,8 @@ fun HomeScreen(
                 )
 
                 agencyRegisterScreen(
-                    navigateToLedger = homeNavController::navigateLedger
+                    navigateToLedger = homeNavController::navigateLedger,
+                    navigateToAgencyJoin = homeNavController::navigateAgencyJoin
                 )
 
                 agencyRegisterCompleteScreen(

--- a/feature/home/src/main/java/com/moneymong/moneymong/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/moneymong/moneymong/home/HomeScreen.kt
@@ -127,7 +127,9 @@ fun HomeScreen(
                 // sign
                 loginScreen(
                     navigateToLedger = homeNavController::navigateLedger,
-                    navigateToAgencyRegister = homeNavController::navigateAgencyRegister
+                    navigateToAgencyRegister = {
+                        homeNavController.navigateAgencyRegister(visibleInviteCode = true)
+                    }
                 )
 
                 signUpScreen(

--- a/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/LedgerScreen.kt
+++ b/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/LedgerScreen.kt
@@ -152,7 +152,6 @@ fun LedgerScreen(
                 modifier = Modifier.background(White),
                 header = state.currentAgency?.name ?: "장부",
                 icon = R.drawable.ic_chevron_bottom,
-                visibleArrow = state.agencyList.isNotEmpty(),
                 onClickDownArrow = viewModel::onClickAgencyChange
             )
         },

--- a/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/view/LedgerTopbarView.kt
+++ b/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/view/LedgerTopbarView.kt
@@ -18,17 +18,16 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.moneymong.moneymong.ui.noRippleClickable
+import com.moneymong.moneymong.design_system.R
 import com.moneymong.moneymong.design_system.theme.Gray10
 import com.moneymong.moneymong.design_system.theme.Heading1
-import com.moneymong.moneymong.design_system.R
+import com.moneymong.moneymong.ui.noRippleClickable
 
 @Composable
 fun LedgerTopbarView(
     modifier: Modifier = Modifier,
     header: String,
     icon: Int,
-    visibleArrow: Boolean = false,
     onClickDownArrow: () -> Unit
 ) {
     Row(
@@ -50,18 +49,16 @@ fun LedgerTopbarView(
             maxLines = 1
         )
         Spacer(modifier = Modifier.width(4.dp))
-        if (visibleArrow) {
-            Icon(
-                modifier = Modifier
-                    .size(20.dp)
-                    .noRippleClickable {
-                        onClickDownArrow()
-                    },
-                painter = painterResource(id = icon),
-                contentDescription = null,
-                tint = Gray10
-            )
-        }
+        Icon(
+            modifier = Modifier
+                .size(20.dp)
+                .noRippleClickable {
+                    onClickDownArrow()
+                },
+            painter = painterResource(id = icon),
+            contentDescription = null,
+            tint = Gray10
+        )
     }
 }
 
@@ -71,6 +68,5 @@ fun LedgerTopbarPreview() {
     LedgerTopbarView(
         header = "장부장부장부장부장부장부장부장부장부",
         icon = R.drawable.ic_chevron_bottom,
-        visibleArrow = true
     ) {}
 }


### PR DESCRIPTION
## 요약
사용자는 로그인 후 소속된 장부가 없다면  **장부 생성 화면**으로 진입하도록 되어 있습니다.
이때 기존 장부에 `가입`하려는 사용자도 반드시 새 장부를 생성해야만 하는 문제가 있었고, 이에 따른 CS 문의가 지속적으로 발생했습니다.

이번 수정으로, **장부 생성 화면**에서 바로 기존 장부에 가입할 수 있는 기능을 추가했습니다.
=> 로그인 → 장부 생성 화면 → (신규 생성 or 기존 장부 가입) 흐름으로 개선되었습니다.

### 추가 수정 사항
**장부 생성 화면**에서 X 버튼 클릭 시 장부 화면으로 이동할 때,
소속된 장부가 없는 경우에는 장부 이름 옆 화살표 아이콘(⬇️ = Bottom Sheet Show)이 보이지 않아
장부 가입이 불가능한 문제가 있었습니다.

이에 따라, 소속 장부가 없더라도 화살표 아이콘(⬇️)이 항상 표시되도록 수정했습니다.

## 작업내용
- [X] 기능개발
- [ ] 버그개선
- [ ] 리팩토링
- [ ] 핫픽스
- [ ] 빌드 파일 수정
- [ ] 기타

## 스크린샷
|기존|수정 후|
|:----:|:----:|
|<img width="200" src="https://github.com/user-attachments/assets/6a80ebac-524b-4e49-9645-6bd22a75e85f">|<img width="200" src="https://github.com/user-attachments/assets/948fe172-1cb1-4489-8501-f1a09a9c78fa">

|기존|수정 후|
|:----:|:----:|
|<img width="200" src="https://github.com/user-attachments/assets/0421b2d2-be66-4b79-bb06-398565cfee2e">|<img width="200" src="https://github.com/user-attachments/assets/d028931e-9d3f-4381-9b85-a82f515e642f">

