### PR TITLE
[ID-52] 장부 API 카테고리 추가

### DIFF
--- a/core/model/src/main/java/com/moneymong/moneymong/model/ledger/LedgerTransactionRequest.kt
+++ b/core/model/src/main/java/com/moneymong/moneymong/model/ledger/LedgerTransactionRequest.kt
@@ -6,5 +6,6 @@ data class LedgerTransactionRequest(
     val amount: Int,
     val description: String,
     val paymentDate: String,
-    val documentImageUrls: List<String> = emptyList()
+    val documentImageUrls: List<String> = emptyList(),
+    val category: String? = null,
 )

--- a/core/model/src/main/java/com/moneymong/moneymong/model/ledgerdetail/LedgerTransactionDetailResponse.kt
+++ b/core/model/src/main/java/com/moneymong/moneymong/model/ledgerdetail/LedgerTransactionDetailResponse.kt
@@ -12,5 +12,6 @@ data class LedgerTransactionDetailResponse(
     val paymentDate: String,
     val receiptImageUrls: List<ReceiptImageURL>,
     val documentImageUrls: List<DocumentImageURL>,
-    val authorName: String
+    val authorName: String,
+    val category: String?,
 )

--- a/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/LedgerScreen.kt
+++ b/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/LedgerScreen.kt
@@ -85,16 +85,14 @@ fun LedgerScreen(
     )
     val analyticsTracker = LocalAnalyticsTracker.current
 
-    LaunchedEffect(Unit) {
-        viewModel.fetchMyAgencyList()
-        viewModel.fetchAgencyMemberList()
-        viewModel.fetchAgencyExistLedger()
+    LaunchedEffect(state.isStaff) {
+        println("isStaff: ${state.isStaff}")
     }
 
     viewModel.collectSideEffect {
         when (it) {
             is LedgerSideEffect.LedgerNavigateToLedgerDetail -> {
-                navigateToLedgerDetail(null, it.id, state.isStaff)
+                navigateToLedgerDetail(null, it.id, it.isStaff)
             }
 
             is LedgerSideEffect.LedgerNavigateToLedgerManual -> {
@@ -236,7 +234,8 @@ fun LedgerScreen(
                                 onClickTransactionItem = {
                                     viewModel.eventEmit(
                                         LedgerSideEffect.LedgerNavigateToLedgerDetail(
-                                            it
+                                            id = it,
+                                            isStaff = state.isStaff,
                                         )
                                     )
                                 },

--- a/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/LedgerScreen.kt
+++ b/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/LedgerScreen.kt
@@ -85,10 +85,6 @@ fun LedgerScreen(
     )
     val analyticsTracker = LocalAnalyticsTracker.current
 
-    LaunchedEffect(state.isStaff) {
-        println("isStaff: ${state.isStaff}")
-    }
-
     viewModel.collectSideEffect {
         when (it) {
             is LedgerSideEffect.LedgerNavigateToLedgerDetail -> {

--- a/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/LedgerSideEffect.kt
+++ b/feature/ledger/src/main/java/com/moneymong/moneymong/ledger/LedgerSideEffect.kt
@@ -7,7 +7,7 @@ sealed class LedgerSideEffect : SideEffect {
     data object LedgerCloseSheet : LedgerSideEffect()
     data object LedgerNavigateToLedgerManual : LedgerSideEffect()
     data object LedgerFetchRetry : LedgerSideEffect()
-    data class LedgerNavigateToLedgerDetail(val id: Int): LedgerSideEffect()
+    data class LedgerNavigateToLedgerDetail(val id: Int, val isStaff: Boolean): LedgerSideEffect()
     data class LedgerSelectedAgencyChange(val agencyId: Int): LedgerSideEffect()
     data class LedgerVisibleSnackbar(val message: String, val withDismissAction: Boolean): LedgerSideEffect()
 }

--- a/feature/ledgerdetail/src/main/java/com/moneymong/moneymong/ledgerdetail/LedgerDetailScreen.kt
+++ b/feature/ledgerdetail/src/main/java/com/moneymong/moneymong/ledgerdetail/LedgerDetailScreen.kt
@@ -53,6 +53,7 @@ import com.moneymong.moneymong.design_system.component.button.MDSButtonSize
 import com.moneymong.moneymong.design_system.component.button.MDSButtonType
 import com.moneymong.moneymong.design_system.component.indicator.LoadingScreen
 import com.moneymong.moneymong.design_system.component.modal.MDSModal
+import com.moneymong.moneymong.design_system.component.tag.MDSOutlineTag
 import com.moneymong.moneymong.design_system.component.textfield.MDSTextField
 import com.moneymong.moneymong.design_system.component.textfield.util.MDSTextFieldIcons
 import com.moneymong.moneymong.design_system.component.textfield.util.withRequiredMark
@@ -376,6 +377,22 @@ fun LedgerDetailScreen(
                             style = Body3,
                             color = Gray10
                         )
+                    }
+                    Box(
+                        modifier = Modifier
+                            .padding(vertical = 20.dp)
+                            .fillMaxWidth()
+                            .height(1.dp)
+                            .background(Gray03, shape = DottedShape(8.dp))
+                    )
+                    Text(
+                        text = "카테고리",
+                        style = Body2,
+                        color = Gray06
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    state.ledgerTransactionDetail?.category?.let {
+                        MDSOutlineTag(text = it)
                     }
                     Box(
                         modifier = Modifier

--- a/feature/ledgerdetail/src/main/java/com/moneymong/moneymong/ledgerdetail/LedgerDetailScreen.kt
+++ b/feature/ledgerdetail/src/main/java/com/moneymong/moneymong/ledgerdetail/LedgerDetailScreen.kt
@@ -178,6 +178,36 @@ fun LedgerDetailScreen(
                 onClickDelete = { viewModel.onChangeVisibleConfirmModal(true) },
                 onClickDone = viewModel::onClickEditButton
             )
+        },
+        bottomBar = {
+            if (state.isStaff) {
+                DisposableEffect(key1 = Unit) {
+                    SystemBarColorController.setNavigationBarColor(color = White)
+
+                    onDispose {
+                        SystemBarColorController.initialSystemBarColors()
+                    }
+                }
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(White)
+                        .padding(horizontal = MMHorizontalSpacing),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Spacer(modifier = Modifier.height(20.dp))
+                    MDSButton(
+                        modifier = Modifier.fillMaxWidth(),
+                        text = "수정하기",
+                        enabled = state.enabledEdit,
+                        size = MDSButtonSize.LARGE,
+                        type = MDSButtonType.PRIMARY,
+                        onClick = viewModel::onClickEditButton
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
+            }
         }
     ) {
         Column(
@@ -484,34 +514,6 @@ fun LedgerDetailScreen(
                 }
             }
             Spacer(modifier = Modifier.height(20.dp))
-            if (state.isStaff) {
-                DisposableEffect(key1 = Unit) {
-                    SystemBarColorController.setNavigationBarColor(color = White)
-
-                    onDispose {
-                        SystemBarColorController.initialSystemBarColors()
-                    }
-                }
-
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(White)
-                        .padding(horizontal = MMHorizontalSpacing),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Spacer(modifier = Modifier.height(20.dp))
-                    MDSButton(
-                        modifier = Modifier.fillMaxWidth(),
-                        text = "수정하기",
-                        enabled = state.enabledEdit,
-                        size = MDSButtonSize.LARGE,
-                        type = MDSButtonType.PRIMARY,
-                        onClick = viewModel::onClickEditButton
-                    )
-                    Spacer(modifier = Modifier.height(12.dp))
-                }
-            }
         }
         if (state.isLoading) {
             LoadingScreen(modifier = Modifier.fillMaxSize())

--- a/feature/ledgerdetail/src/main/java/com/moneymong/moneymong/ledgerdetail/LedgerDetailViewModel.kt
+++ b/feature/ledgerdetail/src/main/java/com/moneymong/moneymong/ledgerdetail/LedgerDetailViewModel.kt
@@ -272,7 +272,7 @@ class LedgerDetailViewModel @Inject constructor(
         reduce { state.copy(isStaff = isStaff) }
     }
 
-    private fun showErrorDialog(message: String?) = intent {
+    private fun showErrorDialog(message: String?) = blockingIntent {
         reduce {
             state.copy(
                 showErrorDialog = true,

--- a/feature/ledgermanual/src/main/java/com/moneymong/moneymong/ledgermanual/LedgerManualViewModel.kt
+++ b/feature/ledgermanual/src/main/java/com/moneymong/moneymong/ledgermanual/LedgerManualViewModel.kt
@@ -64,6 +64,7 @@ class LedgerManualViewModel @Inject constructor(
                 description = state.memoValue.text.ifEmpty { "내용 없음" },
                 paymentDate = state.postPaymentDate,
                 documentImageUrls = state.documentList,
+                category = state.selectedCategory?.name,
             )
             postLedgerTransactionUseCase(state.agencyId, ledgerTransactionRequest)
                 .onSuccess {


### PR DESCRIPTION
## 요약

- 장부 API에 카테고리 컬럼을 추가합니다.
- 장부 상세 화면에서 staff인 경우 수정 버튼이 표시되지 않던 이슈를 해결합니다.
## 작업내용
- [x] 기능개발
- [x] 버그개선
- [ ] 리팩토링
- [ ] 핫픽스
- [ ] 빌드 파일 수정
- [ ] 기타

## 스크린샷

<img width="402" height="897" alt="Screenshot_20251030_002239" src="https://github.com/user-attachments/assets/fa4db708-ed01-42d6-800a-e5c9a979a256" />
## 기타
